### PR TITLE
Fix squeezenet setup.py path separator for WSL

### DIFF
--- a/TensorFlow/squeezenet/setup.py
+++ b/TensorFlow/squeezenet/setup.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 
 def find_cifar2png():
-    for path in  os.environ["PATH"].split(";"):
+    for path in os.environ["PATH"].split(os.pathsep):
         for root,_,files in os.walk(path):
             for filename in files:
                 if filename == "cifar2png":


### PR DESCRIPTION
SqueezeNet's setup.py fails to find cifar2png in WSL: Linux uses `:` for to separate paths in $PATH; Windows uses `;`. Python abstracts this with `os.pathsep`.