### PR TITLE
Reduce min log level for SqueezeNet scripts

### DIFF
--- a/TensorFlow/squeezenet/src/save_squeezenet.py
+++ b/TensorFlow/squeezenet/src/save_squeezenet.py
@@ -1,6 +1,4 @@
 import os
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-
 import tensorflow as tf
 import shutil
 import argparse

--- a/TensorFlow/squeezenet/src/train_squeezenet.py
+++ b/TensorFlow/squeezenet/src/train_squeezenet.py
@@ -1,7 +1,5 @@
 import os
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3' 
 import sys
-
 import tensorflow as tf
 
 from models.research.slim.deployment import model_deploy


### PR DESCRIPTION
`TF_CPP_MIN_LOG_LEVEL = 3` can make it hard or impossible to know what's going on when an error happens. For example, it doesn't tell us if there was a problem while loading DirectML.dll.