### PR TITLE
GRU Operator - Null pointer while determining the output tensor shape

### DIFF
--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -2776,7 +2776,7 @@ namespace dml
             outputSequenceSizes[0] = inputTensor.sizes[1]; // SequenceLength
             outputSequenceSizes[1] = directionCount;
             outputSequenceSizes[2] = inputTensor.sizes[2]; // BatchSize
-            outputSequenceSizes[3] = hiddenInitTensor.sizes[3]; // HiddenSize
+            outputSequenceSizes[3] = recurrenceTensor.sizes[3]; // HiddenSize
             outputSequenceTensor = TensorDesc(inputTensor.dataType, outputSequenceSizes, builder->GetTensorPolicy());
         }
         if (outputOptions == GRUOutputOptions::Single || outputOptions == GRUOutputOptions::Both)
@@ -2784,7 +2784,7 @@ namespace dml
             outputSingleSizes[0] = 1;
             outputSingleSizes[1] = directionCount;
             outputSingleSizes[2] = inputTensor.sizes[2]; // BatchSize
-            outputSingleSizes[3] = hiddenInitTensor.sizes[3]; // HiddenSize
+            outputSingleSizes[3] = recurrenceTensor.sizes[3]; // HiddenSize
             outputSingleTensor = TensorDesc(inputTensor.dataType, outputSingleSizes, builder->GetTensorPolicy());
         }
 


### PR DESCRIPTION
**Motivation**
A user faces null pointer issue while using the GRU operator. [Github Issue: 81](https://github.com/microsoft/DirectML/issues/81)

**Implementation**
In GRU operator to determine the 4th dimension of the output tensor, we were using 4th dimension of optional input _hiddenTensor_. So when this optional input is not provided, the program will throw null pointer exception.
As per the operator [description](https://docs.microsoft.com/en-us/windows/win32/api/directml/ns-directml-dml_gru_operator_desc), we can also use 4th dimension of required input _recurrenceTensor_ to determine the 4th dimension of the output tensor. 

Hidden Tensor size: _{ 1, num_directions, batch_size, **hidden_size** }_
Recurrence Tensor size: _{ 1, num_directions, 3 * hidden_size, **hidden_size** }_