### PR TITLE
Warning fixes in DMLX

### DIFF
--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -2553,7 +2553,6 @@ namespace dml
         TensorDesc inputTensor = input.Impl()->GetOutputDesc();
         TensorDesc indicesTensor = indices.Impl()->GetOutputDesc();
 
-        uint32_t dimensionCount = static_cast<uint32_t>(inputTensor.sizes.size());
         assert(inputDimensionCount >= 1u && inputDimensionCount <= inputTensor.sizes.size());
         assert(indicesDimensionCount >= 1u && indicesDimensionCount <= indicesTensor.sizes.size());
         assert(batchDimensionCount < inputDimensionCount);

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -2562,7 +2562,7 @@ namespace dml
         assert(numberOfCoordinatesPerIndex >= 1u && numberOfCoordinatesPerIndex <= inputDimensionCount - batchDimensionCount);
 
         uint32_t numberOfOutputDimensionsFromInput = inputDimensionCount - batchDimensionCount - numberOfCoordinatesPerIndex;
-        uint32_t outputPaddingAmount = inputTensor.sizes.size() - (indicesDimensionCount + numberOfOutputDimensionsFromInput - 1);
+        uint32_t outputPaddingAmount = static_cast<uint32_t>(inputTensor.sizes.size()) - (indicesDimensionCount + numberOfOutputDimensionsFromInput - 1);
 
         TensorDimensions outputSizes(outputPaddingAmount, 1);
         outputSizes.insert(outputSizes.end(), indicesTensor.sizes.end() - indicesDimensionCount, indicesTensor.sizes.end() - 1);


### PR DESCRIPTION
Fixes two warnings: unreferenced variable and implicit narrowing conversion.