### PR TITLE
Fix MSVC PyDML build.

### DIFF
--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -13,6 +13,12 @@ else()
 # Use the latest C++ standard available for newer features
 set(PYBIND11_CPP_STANDARD /std:c++latest)
 endif()
+
+# ssize_t does not exist for MSVC but SSIZE_T is available in BaseTsd.
+add_definitions(-Dssize_t=SSIZE_T)
+set(CMAKE_REQUIRED_DEFINITIONS -Dssize_t=SSIZE_T)
+set(CMAKE_EXTRA_INCLUDE_FILES BaseTsd.h)
+
 endif()
 
 add_subdirectory(pybind11)


### PR DESCRIPTION
Patch fixes VS2019 build failures by defining the missing `ssize_t` POSIX type in the CMakefile.