### PR TITLE
Enable fast DML resource allocation and residency management.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,8 @@
 	path = Python/pybind11
 	url = https://github.com/pybind/pybind11.git
 	branch = v2.5
+
+[submodule "Python/gpgmm"]
+	path = Python/gpgmm
+	url = https://github.com/intel/gpgmm.git
+	branch = main

--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -21,6 +21,7 @@ set(CMAKE_EXTRA_INCLUDE_FILES BaseTsd.h)
 
 endif()
 
+add_subdirectory(gpgmm)
 add_subdirectory(pybind11)
 
 pybind11_add_module(
@@ -31,6 +32,6 @@ pybind11_add_module(
     )
 
 target_compile_options(pydirectml PRIVATE /W4 /WX)
-target_include_directories(pydirectml PRIVATE pybind11/include ${DML_PATH}/include ${DMLX_PATH})
+target_include_directories(pydirectml PRIVATE pybind11/include gpgmm/src/include gpgmm/ ${DML_PATH}/include ${DMLX_PATH})
 target_link_directories(pydirectml PRIVATE ${DML_PATH}/bin/x64-win)
-target_link_libraries(pydirectml PRIVATE dxgi.lib d3d12.lib directml.lib)
+target_link_libraries(pydirectml PRIVATE gpgmm dxgi.lib d3d12.lib directml.lib)

--- a/Python/src/device.cpp
+++ b/Python/src/device.cpp
@@ -28,15 +28,40 @@ Device::Device(bool useGpu, bool useDebugLayer) :
         }
     }
 
+    ComPtr<IDXGIAdapter> dxgiAdapter;
     if (    !useGpu 
         ||  FAILED(D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_d3d12Device))))
     {
-        Microsoft::WRL::ComPtr<IDXGIFactory4> dxgiFactory;
+        ComPtr<IDXGIFactory4> dxgiFactory;
         ThrowIfFailed(CreateDXGIFactory1(IID_PPV_ARGS(&dxgiFactory)));
-        Microsoft::WRL::ComPtr<IDXGIAdapter3> pAdapter;
-        ThrowIfFailed(dxgiFactory->EnumWarpAdapter(IID_PPV_ARGS(&pAdapter)));
-        ThrowIfFailed(D3D12CreateDevice(pAdapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_d3d12Device)));
+        ThrowIfFailed(dxgiFactory->EnumWarpAdapter(IID_PPV_ARGS(&dxgiAdapter)));
+        ThrowIfFailed(D3D12CreateDevice(dxgiAdapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_d3d12Device)));
     }
+
+    // Lookup the hardware adapter used by the device.
+    if (dxgiAdapter == nullptr){
+        LUID adapterLUID = m_d3d12Device->GetAdapterLuid();
+        ComPtr<IDXGIFactory1> dxgiFactory;
+        ThrowIfFailed(CreateDXGIFactory1(IID_PPV_ARGS(&dxgiFactory)));
+        ComPtr<IDXGIFactory4> dxgiFactory4;
+        ThrowIfFailed(dxgiFactory.As(&dxgiFactory4));
+        dxgiFactory4->EnumAdapterByLuid(adapterLUID, IID_PPV_ARGS(&dxgiAdapter));
+    }
+
+    D3D12_FEATURE_DATA_ARCHITECTURE arch = {};
+    ThrowIfFailed(m_d3d12Device->CheckFeatureSupport(D3D12_FEATURE_ARCHITECTURE, &arch, sizeof(arch)));
+
+    D3D12_FEATURE_DATA_D3D12_OPTIONS options = {};
+    ThrowIfFailed(m_d3d12Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options)));
+
+    gpgmm::d3d12::ALLOCATOR_DESC allocatorDesc = {};
+    allocatorDesc.Adapter = dxgiAdapter;
+    allocatorDesc.Device = m_d3d12Device;
+    allocatorDesc.IsUMA = arch.UMA;
+    allocatorDesc.ResourceHeapTier = options.ResourceHeapTier;
+    ThrowIfFailed(gpgmm::d3d12::ResourceAllocator::CreateAllocator(allocatorDesc, &m_resourceAllocator));
+
+    m_residencyManager = m_resourceAllocator->GetResidencyManager();
 
     D3D12_COMMAND_QUEUE_DESC queueDesc = {};
     queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
@@ -162,7 +187,7 @@ std::vector<pydml::TensorData*> Device::DispatchOperator(
     {
         if (binding.sizeInBytes != 0)
         {
-            binding.buffer = m_inputsResource.Get();
+            binding.buffer = m_inputsResource->GetResource();
         }
     }
 
@@ -170,19 +195,19 @@ std::vector<pydml::TensorData*> Device::DispatchOperator(
     {
         if (binding.sizeInBytes != 0)
         {
-            binding.buffer = m_outputsResource.Get();
+            binding.buffer = m_outputsResource->GetResource();
         }
     }
 
     // The persistent resource should have already been initialized when the operator was initialized
-    assert(m_persistentResource->GetDesc().Width >= bindingProps.PersistentResourceSize);
+    assert(m_persistentResource->GetResource()->GetDesc().Width >= bindingProps.PersistentResourceSize);
 
     // Upload inputs for execution
     std::vector<ID3D12Resource*> buffersToClear =
     {
-        m_inputsResource.Get(),
-        m_temporaryResource.Get(),
-        m_outputsResource.Get()
+        m_inputsResource->GetResource(),
+        m_temporaryResource->GetResource(),
+        m_outputsResource->GetResource()
     };
     
     ClearGpuBuffers(buffersToClear);
@@ -218,17 +243,17 @@ std::vector<pydml::TensorData*> Device::DispatchOperator(
         m_commandList->ResourceBarrier(
             1,
             &CD3DX12_RESOURCE_BARRIER::Transition(
-                m_inputsResource.Get(),
+                m_inputsResource->GetResource(),
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
                 D3D12_RESOURCE_STATE_COPY_DEST)
             );
 
-        m_commandList->CopyBufferRegion(m_inputsResource.Get(), 0, m_uploadHeap.Get(), 0, inputsResourceSize);
+        m_commandList->CopyBufferRegion(m_inputsResource->GetResource(), 0, m_uploadHeap->GetResource(), 0, inputsResourceSize);
 
         m_commandList->ResourceBarrier(
             1,
             &CD3DX12_RESOURCE_BARRIER::Transition(
-                m_inputsResource.Get(),
+                m_inputsResource->GetResource(),
                 D3D12_RESOURCE_STATE_COPY_DEST,
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS)
             );
@@ -239,8 +264,8 @@ std::vector<pydml::TensorData*> Device::DispatchOperator(
 
     DML_BINDING_TABLE_DESC bindingTableDesc = {};
     bindingTableDesc.Dispatchable = op;
-    bindingTableDesc.CPUDescriptorHandle = m_descriptorHeap->GetCPUDescriptorHandleForHeapStart();
-    bindingTableDesc.GPUDescriptorHandle = m_descriptorHeap->GetGPUDescriptorHandleForHeapStart();
+    bindingTableDesc.CPUDescriptorHandle = m_descriptorHeap->m_Heap->GetCPUDescriptorHandleForHeapStart();
+    bindingTableDesc.GPUDescriptorHandle = m_descriptorHeap->m_Heap->GetGPUDescriptorHandleForHeapStart();
     bindingTableDesc.SizeInDescriptors = bindingProps.RequiredDescriptorCount;
 
     ThrowIfFailed(m_bindingTable->Reset(&bindingTableDesc));
@@ -266,20 +291,20 @@ std::vector<pydml::TensorData*> Device::DispatchOperator(
     // Bind persistent/temporary resources
     if (bindingProps.PersistentResourceSize != 0)
     {
-        DML_BUFFER_BINDING persistentBinding = { m_persistentResource.Get(), 0, bindingProps.PersistentResourceSize };
+        DML_BUFFER_BINDING persistentBinding = { m_persistentResource->GetResource(), 0, bindingProps.PersistentResourceSize };
         auto bindingDesc = DML_BINDING_DESC { DML_BINDING_TYPE_BUFFER, &persistentBinding };
         m_bindingTable->BindPersistentResource(&bindingDesc);
     }
 
     if (bindingProps.TemporaryResourceSize != 0)
     {
-        DML_BUFFER_BINDING temporaryBinding = { m_temporaryResource.Get(), 0, bindingProps.TemporaryResourceSize };
+        DML_BUFFER_BINDING temporaryBinding = { m_temporaryResource->GetResource(), 0, bindingProps.TemporaryResourceSize };
         auto bindingDesc = DML_BINDING_DESC { DML_BINDING_TYPE_BUFFER, &temporaryBinding };
         m_bindingTable->BindTemporaryResource(&bindingDesc);
     }
 
     // Record and execute commands, and wait for completion
-    m_commandList->SetDescriptorHeaps(1, m_descriptorHeap.GetAddressOf());
+    m_commandList->SetDescriptorHeaps(1, m_descriptorHeap->m_Heap.GetAddressOf());
     m_commandRecorder->RecordDispatch(m_commandList.Get(), op, m_bindingTable.Get());
     RecordOutputReadBack(outputsResourceSize);
     ExecuteCommandListAndWait();
@@ -296,17 +321,17 @@ void Device::RecordOutputReadBack(uint64_t outputsResourceSize)
         m_commandList->ResourceBarrier(
             1,
             &CD3DX12_RESOURCE_BARRIER::Transition(
-                m_outputsResource.Get(),
+                m_outputsResource->GetResource(),
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
                 D3D12_RESOURCE_STATE_COPY_SOURCE)
             );
 
-        m_commandList->CopyBufferRegion(m_readbackHeap.Get(), 0, m_outputsResource.Get(), 0, outputsResourceSize);
+        m_commandList->CopyBufferRegion(m_readbackHeap->GetResource(), 0, m_outputsResource->GetResource(), 0, outputsResourceSize);
 
         m_commandList->ResourceBarrier(
             1,
             &CD3DX12_RESOURCE_BARRIER::Transition(
-                m_outputsResource.Get(),
+                m_outputsResource->GetResource(),
                 D3D12_RESOURCE_STATE_COPY_SOURCE,
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS)
             );
@@ -410,16 +435,16 @@ void Device::InitializeOperator(
     {
         if (binding.sizeInBytes != 0)
         {
-            binding.buffer = m_inputsResource.Get();
+            binding.buffer = m_inputsResource->GetResource();
         }
     }
 
     // Upload inputs for initialization
     std::vector<ID3D12Resource*> buffersToClear =
     {
-        m_inputsResource.Get(),
-        m_temporaryResource.Get(),
-        m_persistentResource.Get()
+        m_inputsResource->GetResource(),
+        m_temporaryResource->GetResource(),
+        m_persistentResource->GetResource()
     };
 
     ClearGpuBuffers(buffersToClear);
@@ -455,17 +480,17 @@ void Device::InitializeOperator(
         m_commandList->ResourceBarrier(
             1,
             &CD3DX12_RESOURCE_BARRIER::Transition(
-                m_inputsResource.Get(),
+                m_inputsResource->GetResource(),
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
                 D3D12_RESOURCE_STATE_COPY_DEST)
             );
 
-        m_commandList->CopyBufferRegion(m_inputsResource.Get(), 0, m_uploadHeap.Get(), 0, inputsResourceSize);
+        m_commandList->CopyBufferRegion(m_inputsResource->GetResource(), 0, m_uploadHeap->GetResource(), 0, inputsResourceSize);
 
         m_commandList->ResourceBarrier(
             1,
             &CD3DX12_RESOURCE_BARRIER::Transition(
-                m_inputsResource.Get(),
+                m_inputsResource->GetResource(),
                 D3D12_RESOURCE_STATE_COPY_DEST,
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS)
                 );
@@ -476,8 +501,8 @@ void Device::InitializeOperator(
 
     DML_BINDING_TABLE_DESC bindingTableDesc = {};
     bindingTableDesc.Dispatchable = m_operatorInitializer.Get();
-    bindingTableDesc.CPUDescriptorHandle = m_descriptorHeap->GetCPUDescriptorHandleForHeapStart();
-    bindingTableDesc.GPUDescriptorHandle = m_descriptorHeap->GetGPUDescriptorHandleForHeapStart();
+    bindingTableDesc.CPUDescriptorHandle = m_descriptorHeap->m_Heap->GetCPUDescriptorHandleForHeapStart();
+    bindingTableDesc.GPUDescriptorHandle = m_descriptorHeap->m_Heap->GetGPUDescriptorHandleForHeapStart();
     bindingTableDesc.SizeInDescriptors = descriptorHeapSize;
 
     ThrowIfFailed(m_bindingTable->Reset(&bindingTableDesc));
@@ -487,20 +512,20 @@ void Device::InitializeOperator(
 
     if (persistentResourceSize != 0)
     {
-        DML_BUFFER_BINDING outputBinding = { m_persistentResource.Get(), 0, persistentResourceSize };
+        DML_BUFFER_BINDING outputBinding = { m_persistentResource->GetResource(), 0, persistentResourceSize };
         auto desc = DML_BINDING_DESC { DML_BINDING_TYPE_BUFFER, &outputBinding };
         m_bindingTable->BindOutputs(1, &desc);
     }
 
     if (temporaryResourceSize != 0)
     {
-        DML_BUFFER_BINDING temporaryBinding = { m_temporaryResource.Get(), 0, temporaryResourceSize };
+        DML_BUFFER_BINDING temporaryBinding = { m_temporaryResource->GetResource(), 0, temporaryResourceSize };
         auto desc = DML_BINDING_DESC { DML_BINDING_TYPE_BUFFER, &temporaryBinding };
         m_bindingTable->BindTemporaryResource(&desc);
     }
 
     // Record and execute commands, and wait for completion
-    m_commandList->SetDescriptorHeaps(1, m_descriptorHeap.GetAddressOf());
+    m_commandList->SetDescriptorHeaps(1, m_descriptorHeap->m_Heap.GetAddressOf());
     m_commandRecorder->RecordDispatch(m_commandList.Get(), m_operatorInitializer.Get(), m_bindingTable.Get());
     ExecuteCommandListAndWait();
 }
@@ -510,25 +535,34 @@ void Device::ExecuteCommandListAndWait()
     ThrowIfFailed(m_commandList->Close());
 
     ID3D12CommandList* commandLists[] = { m_commandList.Get() };
-    m_commandQueue->ExecuteCommandLists(ARRAYSIZE(commandLists), commandLists);
+    if (m_residencyManager != nullptr){
+        gpgmm::d3d12::ResidencySet* residencySets[] = { &m_residencySet };
+        m_residencyManager->ExecuteCommandLists(m_commandQueue.Get(), commandLists, residencySets, ARRAYSIZE(commandLists));
+    } else {
+        m_commandQueue->ExecuteCommandLists(ARRAYSIZE(commandLists), commandLists);
+    }
 
     WaitForQueueToComplete(m_commandQueue.Get());
 
     ThrowIfFailed(m_commandAllocator->Reset());
     ThrowIfFailed(m_commandList->Reset(m_commandAllocator.Get(), nullptr));
+
+    if (m_residencyManager != nullptr){
+        ThrowIfFailed(m_residencySet.Reset());
+    }
 }
 
 void Device::EnsureUploadHeapSize(uint64_t requestedSizeInBytes)
 {
-    uint64_t existingSize = m_uploadHeap ? m_uploadHeap->GetDesc().Width : 0;
+    uint64_t existingSize = m_uploadHeap ? m_uploadHeap->GetResource()->GetDesc().Width : 0;
     uint64_t newSize = RoundUpToPow2(requestedSizeInBytes);     // ensures geometric growth
     newSize = std::max(newSize, static_cast<uint64_t>(65536));  // Minimum size of 64k
 
     if (newSize != existingSize)
     {
         m_uploadHeap = nullptr;
-        m_uploadHeap = CreateCommittedResource(
-            m_d3d12Device.Get(),
+        m_uploadHeap = CreateResource(
+            m_resourceAllocator.Get(),
             CD3DX12_RESOURCE_DESC::Buffer(newSize),
             CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
             D3D12_RESOURCE_STATE_GENERIC_READ
@@ -536,7 +570,7 @@ void Device::EnsureUploadHeapSize(uint64_t requestedSizeInBytes)
     }
 }
 
-void Device::EnsureCpuOrDefaultBufferSize(uint64_t requestedSizeInBytes, _Inout_ ComPtr<ID3D12Resource>& buffer)
+void Device::EnsureCpuOrDefaultBufferSize(uint64_t requestedSizeInBytes, _Inout_ ComPtr<gpgmm::d3d12::ResourceAllocation>& buffer)
 {
     if (m_useCpuCustomHeapResources)
     {
@@ -548,61 +582,83 @@ void Device::EnsureCpuOrDefaultBufferSize(uint64_t requestedSizeInBytes, _Inout_
     }
 }
 
-void Device::EnsureCpuBufferSize(uint64_t requestedSizeInBytes, _Inout_ ComPtr<ID3D12Resource>& buffer)
+void Device::EnsureCpuBufferSize(uint64_t requestedSizeInBytes, _Inout_ ComPtr<gpgmm::d3d12::ResourceAllocation>& buffer)
 {
-    uint64_t existingSize = buffer ? buffer->GetDesc().Width : 0;
+    uint64_t existingSize = buffer ? buffer->GetResource()->GetDesc().Width : 0;
     uint64_t newSize = RoundUpToPow2(requestedSizeInBytes);     // ensures geometric growth
     newSize = std::max(newSize, static_cast<uint64_t>(65536));  // Minimum size of 64k
 
     if (newSize != existingSize)
     {
         buffer = nullptr;
-        buffer = CreateCpuCustomBuffer(m_d3d12Device.Get(), newSize);
+        buffer = CreateCpuCustomBuffer(m_resourceAllocator.Get(), newSize);
     }
+
+    buffer->UpdateResidency(&m_residencySet);
 }
 
-void Device::EnsureDefaultBufferSize(uint64_t requestedSizeInBytes, _Inout_ ComPtr<ID3D12Resource>& buffer)
+void Device::EnsureDefaultBufferSize(uint64_t requestedSizeInBytes, _Inout_ ComPtr<gpgmm::d3d12::ResourceAllocation>& buffer)
 {
-    uint64_t existingSize = buffer ? buffer->GetDesc().Width : 0;
+    uint64_t existingSize = buffer ? buffer->GetResource()->GetDesc().Width : 0;
     uint64_t newSize = RoundUpToPow2(requestedSizeInBytes);     // ensures geometric growth
     newSize = std::max(newSize, static_cast<uint64_t>(65536));  // Minimum size of 64k
 
     if (newSize != existingSize)
     {
         buffer = nullptr;
-        buffer = CreateDefaultBuffer(m_d3d12Device.Get(), newSize);
+        buffer = CreateDefaultBuffer(m_resourceAllocator.Get(), newSize);
     }
+
+    buffer->UpdateResidency(&m_residencySet);
 }
 
 void Device::EnsureDescriptorHeapSize(uint32_t requestedSizeInDescriptors)
 {
-    uint32_t existingSize = m_descriptorHeap ? m_descriptorHeap->GetDesc().NumDescriptors : 0;
+    uint32_t existingSize = m_descriptorHeap ? m_descriptorHeap->m_Heap->GetDesc().NumDescriptors : 0;
     uint32_t newSize = RoundUpToPow2(requestedSizeInDescriptors); // ensures geometric growth
 
     if (newSize != existingSize)
     {
+        if (m_residencyManager != nullptr){
+            m_residencyManager->UnlockHeap(m_descriptorHeap.get());
+        }
+
         m_descriptorHeap = nullptr;
+
+        if (m_residencyManager != nullptr){
+            ThrowIfFailed(m_residencyManager->Evict(newSize, DXGI_MEMORY_SEGMENT_GROUP_LOCAL));
+        }
 
         D3D12_DESCRIPTOR_HEAP_DESC desc = {};
         desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
         desc.NumDescriptors = newSize;
         desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
 
-        ThrowIfFailed(m_d3d12Device->CreateDescriptorHeap(&desc, IID_GRAPHICS_PPV_ARGS(m_descriptorHeap.GetAddressOf())));
+        ComPtr<ID3D12DescriptorHeap> d3d12DescriptorHeap;
+        ThrowIfFailed(m_d3d12Device->CreateDescriptorHeap(&desc, IID_GRAPHICS_PPV_ARGS(d3d12DescriptorHeap.GetAddressOf())));
+    
+        m_descriptorHeap = std::make_unique<SVDescriptorHeap>(std::move(d3d12DescriptorHeap), newSize);
+
+        if (m_residencyManager != nullptr){
+            ThrowIfFailed(m_residencyManager->InsertHeap(m_descriptorHeap.get()));
+            ThrowIfFailed(m_residencyManager->LockHeap(m_descriptorHeap.get()));
+        }
     }
 }
 
 void Device::EnsureReadBackHeapSize(uint64_t requestedSizeInBytes)
 {
-    uint64_t existingSize = m_readbackHeap ? m_readbackHeap->GetDesc().Width : 0;
+    uint64_t existingSize = m_readbackHeap ? m_readbackHeap->GetResource()->GetDesc().Width : 0;
     uint64_t newSize = RoundUpToPow2(requestedSizeInBytes); // ensures geometric growth
     newSize = std::max(newSize, static_cast<uint64_t>(65536)); // Minimum size of 64k
 
     if (newSize != existingSize)
     {
         m_readbackHeap = nullptr;
-        m_readbackHeap = CreateReadBackBuffer(m_d3d12Device.Get(), newSize);
+        m_readbackHeap = CreateReadBackBuffer(m_resourceAllocator.Get(), newSize);
     }
+    
+    m_readbackHeap->UpdateResidency(&m_residencySet);
 }
 
 void Device::ClearGpuBuffers(dml::Span<ID3D12Resource*> buffers)

--- a/Python/src/util.h
+++ b/Python/src/util.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <gpgmm_d3d12.h>
+
 inline void ThrowIfFailed(HRESULT hr)
 {
     if (FAILED(hr))
@@ -106,28 +108,29 @@ struct DmlBufferArrayBinding
     }
 };
 
-inline Microsoft::WRL::ComPtr<ID3D12Resource> CreateCommittedResource(
-    ID3D12Device* device,
+inline Microsoft::WRL::ComPtr<gpgmm::d3d12::ResourceAllocation> CreateResource(
+    gpgmm::d3d12::ResourceAllocator* resourceAllocator,
     const D3D12_RESOURCE_DESC& resourceDesc,
     const D3D12_HEAP_PROPERTIES& heapProperties,
     D3D12_RESOURCE_STATES initialState
     )
 {
-    Microsoft::WRL::ComPtr<ID3D12Resource> resource;
-    ThrowIfFailed(device->CreateCommittedResource(
-        &heapProperties,
-        D3D12_HEAP_FLAG_NONE,
-        &resourceDesc,
+    gpgmm::d3d12::ALLOCATION_DESC allocationDesc = {};
+    allocationDesc.HeapType = heapProperties.Type;
+
+    Microsoft::WRL::ComPtr<gpgmm::d3d12::ResourceAllocation> resource;
+    ThrowIfFailed(resourceAllocator->CreateResource(
+        allocationDesc,
+        resourceDesc,
         initialState,
         nullptr,
-        IID_GRAPHICS_PPV_ARGS(resource.GetAddressOf())
-        ));
+        resource.GetAddressOf()));
 
     return resource;
 }
 
-inline Microsoft::WRL::ComPtr<ID3D12Resource> CreateCpuCustomBuffer(
-    ID3D12Device* device,
+inline Microsoft::WRL::ComPtr<gpgmm::d3d12::ResourceAllocation> CreateCpuCustomBuffer(
+    gpgmm::d3d12::ResourceAllocator* resourceAllocator,
     UINT64 sizeInBytes,
     D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS
     )
@@ -140,32 +143,32 @@ inline Microsoft::WRL::ComPtr<ID3D12Resource> CreateCpuCustomBuffer(
         0
     };
 
-    return CreateCommittedResource(
-        device,
+    return CreateResource(
+        resourceAllocator,
         CD3DX12_RESOURCE_DESC::Buffer(sizeInBytes, flags),
         heapProperties,
         D3D12_RESOURCE_STATE_UNORDERED_ACCESS
         );
 }
 
-inline Microsoft::WRL::ComPtr<ID3D12Resource> CreateDefaultBuffer(
-    ID3D12Device* device,
+inline Microsoft::WRL::ComPtr<gpgmm::d3d12::ResourceAllocation> CreateDefaultBuffer(
+    gpgmm::d3d12::ResourceAllocator* resourceAllocator,
     UINT64 sizeInBytes,
     D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS
     )
 {
-    return CreateCommittedResource(
-        device,
+    return CreateResource(
+        resourceAllocator,
         CD3DX12_RESOURCE_DESC::Buffer(sizeInBytes, flags),
         CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
         D3D12_RESOURCE_STATE_UNORDERED_ACCESS
         );
 }
 
-inline Microsoft::WRL::ComPtr<ID3D12Resource> CreateReadBackBuffer(ID3D12Device* device, UINT64 sizeInBytes)
+inline Microsoft::WRL::ComPtr<gpgmm::d3d12::ResourceAllocation> CreateReadBackBuffer(gpgmm::d3d12::ResourceAllocator* resourceAllocator, UINT64 sizeInBytes)
 {
-    return CreateCommittedResource(
-        device,
+    return CreateResource(
+        resourceAllocator,
         CD3DX12_RESOURCE_DESC::Buffer(sizeInBytes),
         CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK),
         D3D12_RESOURCE_STATE_COPY_DEST


### PR DESCRIPTION
@wchao1115 @adtsai

This is the resource/residency management work that was developed with the help of the D3D12 team (based on 11on12 and D3D12 residency starter library), which was originally developed for Edge then forked to support more D3D12/DML-based projects which either lacked residency support and/or sub-allocation. This VidMM API is 1:1 with D3D12 so there is minimal to no integration overhead with DML. Users would configure the allocators to balance speed vs memory as they require.

PTAL, we are deploying it in a downstream DML project (WebNN) but it seems like there would be more beneifit adding it here. WDYT?