### PR TITLE
Update link to pytorch-directml on PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ DirectML acceleration for PyTorch 1.8.0 is currently available for Public Previe
 PyTorch on DirectML is supported on both the latest versions of Windows 10 and the [Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/about), and is available for download as a PyPI package. For more information about getting started, see [GPU accelerated ML training (docs.microsoft.com)](http://aka.ms/gpuinwsldocs)
 
 * [PyTorch on DirectML samples](./PyTorch)
-* [pytorch-directml PyPI project](https://pypi.org/project/tensorflow-directml/)
+* [pytorch-directml PyPI project](https://pypi.org/project/pytorch-directml/)
 * [PyTorch homepage](https://pytorch.org/)
 
 ## Feedback


### PR DESCRIPTION
Update link to pytorch-directml on PyPi

Issue: Link to PyTorch-DirectML on PyPi is pointing to Tensorflow-directml.

Fix: Update the link.