### PR TITLE
Fix documentation around how to install pytorch-directml

### DIFF
--- a/PyTorch/README.md
+++ b/PyTorch/README.md
@@ -16,8 +16,9 @@ Follow the steps below to get set up with PyTorch on DirectML.
 
 3. Install prerequisites
 ```
-    pip install -r pytorch\requirements.txt 
+    pip install torchvision==0.9.0
     pip uninstall torch
+    pip install pytorch-directml
 ```
 
 > Note: The torchvision package automatically installs the torch==1.8.0 dependency, but this is not needed and will cause collisions with the pytorch-directml package. We must uninstall the torch package after installing requirements.

--- a/PyTorch/requirements.txt
+++ b/PyTorch/requirements.txt
@@ -1,2 +1,0 @@
-torchvision==0.9.0
-pytorch-directml


### PR DESCRIPTION
GitHub Issue: https://github.com/microsoft/DirectML/issues/168

Docs provide setup steps that lead to lead to pytorch-directml being installed prior to the torch package being uninstalled.
==> AttributeError: module 'torch' has no attribute 'tensor'

Fix: 
pip install torchvision==0.9.0
pip uninstall torch
pip install pytorch-directml