### PR TITLE
Misc. improvements to DirectMLX.h

### DIFF
--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -2091,14 +2091,14 @@ namespace dml
         // Calculate output size, if not explicitly provided
         if (outputSizes.empty())
         {
-        outputSizes.push_back(inputTensor.sizes[0]); // N
-        outputSizes.push_back(inputTensor.sizes[1]); // C
-        for (size_t i = 0; i < windowSizes.size(); ++i)
-        {
-            uint32_t paddedInputSize = inputTensor.sizes[2 + i] + startPadding[i] + endPadding[i];
-            uint32_t outputSize = (paddedInputSize - windowSizes[i]) / strides[i] + 1;
-            outputSizes.push_back(outputSize);
-        }
+            outputSizes.push_back(inputTensor.sizes[0]); // N
+            outputSizes.push_back(inputTensor.sizes[1]); // C
+            for (size_t i = 0; i < windowSizes.size(); ++i)
+            {
+                uint32_t paddedInputSize = inputTensor.sizes[2 + i] + startPadding[i] + endPadding[i];
+                uint32_t outputSize = (paddedInputSize - windowSizes[i]) / strides[i] + 1;
+                outputSizes.push_back(outputSize);
+            }
         }
 
         TensorDesc outputTensor(inputTensor.dataType, std::move(outputSizes), builder->GetTensorPolicy());
@@ -2171,15 +2171,15 @@ namespace dml
         // Calculate output size, if not explicitly provided
         if (outputSizes.empty())
         {
-        outputSizes.push_back(inputTensor.sizes[0]); // N
-        outputSizes.push_back(inputTensor.sizes[1]); // C
-        for (size_t i = 0; i < windowSize.size(); i++)
-        {
-            uint32_t paddedInputSize = inputTensor.sizes[2 + i] + startPadding[i] + endPadding[i];
-            uint32_t dilatedWindowSize = 1 + (windowSize[i] - 1) * dilations[i];
-            uint32_t outputSize = (dilatedWindowSize >= paddedInputSize) ? 1 : (paddedInputSize - dilatedWindowSize) / strides[i] + 1;
-            outputSizes.push_back(outputSize);
-        }
+            outputSizes.push_back(inputTensor.sizes[0]); // N
+            outputSizes.push_back(inputTensor.sizes[1]); // C
+            for (size_t i = 0; i < windowSize.size(); i++)
+            {
+                uint32_t paddedInputSize = inputTensor.sizes[2 + i] + startPadding[i] + endPadding[i];
+                uint32_t dilatedWindowSize = 1 + (windowSize[i] - 1) * dilations[i];
+                uint32_t outputSize = (dilatedWindowSize >= paddedInputSize) ? 1 : (paddedInputSize - dilatedWindowSize) / strides[i] + 1;
+                outputSizes.push_back(outputSize);
+            }
         }
 
         TensorDesc outputTensor(inputTensor.dataType, outputSizes, builder->GetTensorPolicy());

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -658,6 +658,10 @@ namespace dml
         {
             detail::GraphDesc graph = m_graphBuilder->GetGraphDesc(outputs);
 
+            // If supplied, the requested number of inputs to the compiled operator can be larger than the actual
+            // number of input nodes on the graph (e.g. in the case of unused empty inputs), but never smaller.
+            assert(inputCount == 0 || inputCount >= graph.inputCount);
+
             std::vector<DML_GRAPH_NODE_DESC> graphNodes(graph.nodes.size());
             for (size_t i = 0; i < graphNodes.size(); ++i)
             {

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -1846,12 +1846,7 @@ namespace dml
         desc.GroupCount = groupCount;
         desc.FusedActivation = detail::GetFusedActivationPtr(fusedActivation, &storage);
 
-        SmallVector<detail::NodeOutput*, 3> inputs = { input.Impl(), filter.Impl() };
-        if (bias)
-        {
-            inputs.push_back(bias->Impl());
-        }
-
+        detail::NodeOutput* const inputs[] = { input.Impl(), filter.Impl(), bias ? bias->Impl() : nullptr };
         detail::NodeID node = builder->CreateOperatorNode(DML_OPERATOR_CONVOLUTION, &desc, inputs);
         detail::NodeOutput* output = builder->CreateNodeOutput(node, 0, std::move(outputTensor));
 
@@ -1964,12 +1959,7 @@ namespace dml
         desc.Beta = beta;
         desc.FusedActivation = detail::GetFusedActivationPtr(fusedActivation, &storage);
 
-        SmallVector<detail::NodeOutput*, 3> inputs = { a.Impl(), b.Impl() };
-        if (c)
-        {
-            inputs.push_back(c->Impl());
-        }
-
+        detail::NodeOutput* const inputs[] = { a.Impl(), b.Impl(), c ? c->Impl() : nullptr };
         detail::NodeID node = builder->CreateOperatorNode(DML_OPERATOR_GEMM, &desc, inputs);
         detail::NodeOutput* output = builder->CreateNodeOutput(node, 0, std::move(outputTensor));
 
@@ -2941,13 +2931,7 @@ namespace dml
         desc.Epsilon = epsilon;
         desc.FusedActivation = detail::GetFusedActivationPtr(fusedActivation, &storage);
 
-        SmallVector<detail::NodeOutput*, 4> inputs = { input.Impl(), scale.Impl(), bias.Impl() };
-
-        if (fusedAdd)
-        {
-            inputs.push_back(fusedAdd->Impl());
-        }
-
+        detail::NodeOutput* const inputs[] = { input.Impl(), scale.Impl(), bias.Impl(), fusedAdd ? fusedAdd->Impl() : nullptr };
         detail::NodeID node = builder->CreateOperatorNode(DML_OPERATOR_BATCH_NORMALIZATION_TRAINING, &desc, inputs);
         detail::NodeOutput* output         = builder->CreateNodeOutput(node, 0, std::move(outputTensor));
         detail::NodeOutput* outputMean     = builder->CreateNodeOutput(node, 1, std::move(outputMeanTensor));


### PR DESCRIPTION
- Include wrl/client.h for cases where it's not already pulled in by e.g. windows.h
- Add support for unused/empty graph inputs, which can be useful for e.g. using a graph to emulate a larger operator.
- Add an explicit bool conversion for Expression, to allow for easy testing of empty expressions. (`if (expr) {}`)
- Allow a custom output datatype for QuantizeLinear, which is useful for selecting INT8 vs UINT8.
- Consistently use NULLs to represent empty, optional inputs for Conv, Gemm, and BatchNormTraining. In these cases the old code happened to work (because they only have a single optional input), but this change is to be consistent with #210 and help prevent further bugs.