### PR TITLE
Update Reduce in DirectMLX.h to take in output type for argmin/argmax

### DIFF
--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -2004,7 +2004,11 @@ namespace dml
     // ---------------------------------------------------------------------------------------------------------------
 
     // If `axes` is not specified, by default this reduces the entire tensor to single element.
-    inline Expression Reduce(Expression input, DML_REDUCE_FUNCTION function, Span<const uint32_t> axes = {})
+    inline Expression Reduce(
+        Expression input, 
+        DML_REDUCE_FUNCTION function, 
+        DML_TENSOR_DATA_TYPE targetDataType = DML_TENSOR_DATA_TYPE_UNKNOWN, 
+        Span<const uint32_t> axes = {})
     {
         detail::GraphBuilder* builder = input.Impl()->GetGraphBuilder();
         TensorDesc inputTensor = input.Impl()->GetOutputDesc();
@@ -2037,12 +2041,16 @@ namespace dml
             }
         }
 
-        // ARGMIN and ARGMAX reduction produce a UINT32 output; all other reductions produce an output with the same
-        // type as the input.
+        // All reductions other than ARGMIN and ARGMAX produce an output with the same type
+        // as the input.
         DML_TENSOR_DATA_TYPE outputDataType;
         if (function == DML_REDUCE_FUNCTION_ARGMIN || function == DML_REDUCE_FUNCTION_ARGMAX)
         {
-            outputDataType = DML_TENSOR_DATA_TYPE_UINT32;
+            // Default to UINT32 if the output type wasn't specified
+            if (targetDataType = DML_TENSOR_DATA_TYPE_UNKNOWN) {
+                targetDataType = DML_TENSOR_DATA_TYPE_UINT32;
+            }
+            outputDataType = targetDataType;
         }
         else
         {

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -2043,17 +2043,17 @@ namespace dml
 
         // All reductions other than ARGMIN and ARGMAX produce an output with the same type
         // as the input.
-        if (function == DML_REDUCE_FUNCTION_ARGMIN || function == DML_REDUCE_FUNCTION_ARGMAX)
+        if (outputDataType == DML_TENSOR_DATA_TYPE_UNKNOWN) 
         {
-            // Default to UINT32 if the output type wasn't specified
-            if (outputDataType = DML_TENSOR_DATA_TYPE_UNKNOWN) 
+            if (function == DML_REDUCE_FUNCTION_ARGMIN || function == DML_REDUCE_FUNCTION_ARGMAX)
             {
+                // Default to UINT32 if the output type wasn't specified
                 outputDataType = DML_TENSOR_DATA_TYPE_UINT32;
             }
-        }
-        else
-        {
-            outputDataType = inputTensor.dataType;
+            else
+            {
+                outputDataType = inputTensor.dataType;
+            }
         }
 
         TensorDesc outputTensor(outputDataType, std::move(outputSizes), builder->GetTensorPolicy());

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -2008,7 +2008,7 @@ namespace dml
         Expression input, 
         DML_REDUCE_FUNCTION function, 
         Span<const uint32_t> axes = {},
-        DML_TENSOR_DATA_TYPE outputDataType = DML_TENSOR_DATA_TYPE_UINT32)
+        DML_TENSOR_DATA_TYPE outputDataType = DML_TENSOR_DATA_TYPE_UNKNOWN)
     {
         detail::GraphBuilder* builder = input.Impl()->GetGraphBuilder();
         TensorDesc inputTensor = input.Impl()->GetOutputDesc();
@@ -2043,7 +2043,15 @@ namespace dml
 
         // All reductions other than ARGMIN and ARGMAX produce an output with the same type
         // as the input.
-        if (function != DML_REDUCE_FUNCTION_ARGMIN && function != DML_REDUCE_FUNCTION_ARGMAX)
+        if (function == DML_REDUCE_FUNCTION_ARGMIN || function == DML_REDUCE_FUNCTION_ARGMAX)
+        {
+            // Default to UINT32 if the output type wasn't specified
+            if (outputDataType = DML_TENSOR_DATA_TYPE_UNKNOWN) 
+            {
+                outputDataType = DML_TENSOR_DATA_TYPE_UINT32;
+            }
+        }
+        else
         {
             outputDataType = inputTensor.dataType;
         }

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -2007,8 +2007,8 @@ namespace dml
     inline Expression Reduce(
         Expression input, 
         DML_REDUCE_FUNCTION function, 
-        DML_TENSOR_DATA_TYPE targetDataType = DML_TENSOR_DATA_TYPE_UNKNOWN, 
-        Span<const uint32_t> axes = {})
+        Span<const uint32_t> axes = {},
+        DML_TENSOR_DATA_TYPE outputDataType = DML_TENSOR_DATA_TYPE_UINT32)
     {
         detail::GraphBuilder* builder = input.Impl()->GetGraphBuilder();
         TensorDesc inputTensor = input.Impl()->GetOutputDesc();
@@ -2043,16 +2043,7 @@ namespace dml
 
         // All reductions other than ARGMIN and ARGMAX produce an output with the same type
         // as the input.
-        DML_TENSOR_DATA_TYPE outputDataType;
-        if (function == DML_REDUCE_FUNCTION_ARGMIN || function == DML_REDUCE_FUNCTION_ARGMAX)
-        {
-            // Default to UINT32 if the output type wasn't specified
-            if (targetDataType = DML_TENSOR_DATA_TYPE_UNKNOWN) {
-                targetDataType = DML_TENSOR_DATA_TYPE_UINT32;
-            }
-            outputDataType = targetDataType;
-        }
-        else
+        if (function != DML_REDUCE_FUNCTION_ARGMIN && function != DML_REDUCE_FUNCTION_ARGMAX)
         {
             outputDataType = inputTensor.dataType;
         }


### PR DESCRIPTION
Currently, argmin/argmax only output UINT32 for dml::Reduce(); however, this is based on an older version of DML and INT64 output types should now be supported as well.