### PR TITLE
Update samples to use DML 1.9.0, and other small additions

### DIFF
--- a/Samples/DirectMLSuperResolution/DirectMLSuperResolution.vcxproj
+++ b/Samples/DirectMLSuperResolution/DirectMLSuperResolution.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props')" />
+  <Import Project="packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -559,15 +559,15 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets')" />
+    <Import Project="packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets')" />
     <Import Project="packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets" Condition="Exists('packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets'))" />
     <Error Condition="!Exists('packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets'))" />
   </Target>
 </Project>

--- a/Samples/DirectMLSuperResolution/DirectMLXSuperResolution.vcxproj
+++ b/Samples/DirectMLSuperResolution/DirectMLXSuperResolution.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props')" />
+  <Import Project="packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -562,14 +562,14 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets" Condition="Exists('packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets')" />
-    <Import Project="packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets')" />
+    <Import Project="packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets'))" />
   </Target>
 </Project>

--- a/Samples/DirectMLSuperResolution/Readme.md
+++ b/Samples/DirectMLSuperResolution/Readme.md
@@ -1,3 +1,15 @@
+---
+page_type: sample
+languages:
+- cpp
+products:
+- windows
+- xbox
+name: DirectMLSuperResolution
+urlFragment: DirectMLSuperResolution
+description: This sample demonstrates the DirectML API by implementing a super-resolution machine learning (ML) model on the GPU. This includes converting between image and tensor formats, initializing and executing ML operators, and interleaving graphics and ML work. The ML model performs a smart upscale of an image to double its original resolution. For example, it can scale a 540p image to 1080p.
+---
+
 # DirectMLSuperResolution
 For more information see this [Word document](Readme.docx).
 # Privacy Statement

--- a/Samples/DirectMLSuperResolution/packages.config
+++ b/Samples/DirectMLSuperResolution/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AI.DirectML" version="1.7.0" targetFramework="native" />
+  <package id="Microsoft.AI.DirectML" version="1.9.0" targetFramework="native" />
   <package id="WinPixEventRuntime" version="1.0.210209001" targetFramework="native" />
 </packages>

--- a/Samples/HelloDirectML/HelloDirectML.vcxproj
+++ b/Samples/HelloDirectML/HelloDirectML.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props')" />
+  <Import Project="packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -354,13 +354,13 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets')" />
+    <Import Project="packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets'))" />
   </Target>
 </Project>

--- a/Samples/HelloDirectML/HelloDirectMLX.vcxproj
+++ b/Samples/HelloDirectML/HelloDirectMLX.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props')" />
+  <Import Project="packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -354,13 +354,13 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets')" />
+    <Import Project="packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets'))" />
   </Target>
 </Project>

--- a/Samples/HelloDirectML/packages.config
+++ b/Samples/HelloDirectML/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AI.DirectML" version="1.7.0" targetFramework="native" />
+  <package id="Microsoft.AI.DirectML" version="1.9.0" targetFramework="native" />
 </packages>

--- a/Samples/HelloDirectML/readme.md
+++ b/Samples/HelloDirectML/readme.md
@@ -1,3 +1,14 @@
+---
+page_type: sample
+languages:
+- cpp
+products:
+- windows
+- xbox
+name: HelloDirectML
+urlFragment: HelloDirectML
+---
+
 # HelloDirectML sample
 
 A minimal but complete DirectML sample that demonstrates how to initialize D3D12 and DirectML, create and compile an operator, execute the operator on the GPU, and retrieve the results.

--- a/Samples/yolov4/Readme.md
+++ b/Samples/yolov4/Readme.md
@@ -1,3 +1,14 @@
+---
+page_type: sample
+languages:
+- cpp
+products:
+- windows
+- xbox
+name: DirectML YOLOv4 sample
+urlFragment: DirectML-YOLOv4
+---
+
 # YOLOv4 sample
 
 Implements the YOLOv4 real-time object detection model using DirectML and DirectMLX.

--- a/Samples/yolov4/packages.config
+++ b/Samples/yolov4/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AI.DirectML" version="1.7.0" targetFramework="native" />
+  <package id="Microsoft.AI.DirectML" version="1.9.0" targetFramework="native" />
   <package id="WinPixEventRuntime" version="1.0.210209001" targetFramework="native" />
 </packages>

--- a/Samples/yolov4/yolov4.cpp
+++ b/Samples/yolov4/yolov4.cpp
@@ -289,11 +289,6 @@ void Sample::Update(DX::StepTimer const& timer)
                 m_player->Play();
             }
         }
-
-        const float TriggerR = pad.triggers.right;
-        const float TriggerL = pad.triggers.left;
-        const float ThumbLeftX = pad.thumbSticks.leftX;
-        const float ThumbLeftY = pad.thumbSticks.leftY;
     }
     else
     {
@@ -344,7 +339,9 @@ void Sample::GetModelPredictions(
     const uint32_t predTensorN = modelOutput.desc.sizes[0];
     const uint32_t predTensorH = modelOutput.desc.sizes[1];
     const uint32_t predTensorW = modelOutput.desc.sizes[2];
+#if _DEBUG
     const uint32_t predTensorC = modelOutput.desc.sizes[3];
+#endif
 
     // YoloV4 predicts 3 boxes per scale, so we expect 3 separate predictions here
     assert(predTensorN == 3);

--- a/Samples/yolov4/yolov4.vcxproj
+++ b/Samples/yolov4/yolov4.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props')" />
+  <Import Project="packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -566,7 +566,7 @@ copy $(ProjectDir)data\. $(OutDir)data</Command>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets" Condition="Exists('packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets')" />
-    <Import Project="packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets')" />
+    <Import Project="packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets')" />
   </ImportGroup>
   <Target Name="DownloadContentFiles" BeforeTargets="PrepareForBuild" Condition="!Exists('Data\yolov4.weights')">
     <DownloadFile SourceUrl="https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v3_optimal/yolov4.weights" DestinationFolder="$(MSBuildProjectDirectory)\Data">
@@ -578,7 +578,7 @@ copy $(ProjectDir)data\. $(OutDir)data</Command>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.7.0\build\Microsoft.AI.DirectML.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.9.0\build\Microsoft.AI.DirectML.targets'))" />
   </Target>
 </Project>


### PR DESCRIPTION
- Update DirectML samples to use DML version 1.9.0
- Add metadata to readmes for sample browser automation
- Fix a couple of warnings when building yolov4 sample in VS2022