### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/DxDispatch/cgmanifest.json
+++ b/DxDispatch/cgmanifest.json
@@ -1,124 +1,125 @@
 {
-    "Registrations": [
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "commitHash": "302302b30839505703d37fb82f536c53cf9172fa",
-                    "repositoryUrl": "https://github.com/jarro2783/cxxopts"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "nuget",
-                "nuget": {
-                    "name": "Microsoft.Direct3D.D3D12",
-                    "version": "1.606.3"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "nuget",
-                "nuget": {
-                    "name": "Microsoft.AI.DirectML",
-                    "version": "1.9.0"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "other",
-                "other": {
-                    "name": "DirectX Shader Compiler",
-                    "version": "2022_07_18",
-                    "downloadUrl": "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2207/dxc_2022_07_18.zip"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "commitHash": "da7aedbc4a81e9c3bbc80bcface65c91e62fd205",
-                    "repositoryUrl": "https://github.com/microsoft/DirectX-Headers"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "commitHash": "7bdf0628b1276379886c7f6dda2cef2b3b374f0b",
-                    "repositoryUrl": "https://github.com/fmtlib/fmt"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "commitHash": "c1cbb41b428f15e53454682a45f03ea31f1da0a7",
-                    "repositoryUrl": "https://github.com/microsoft/GSL"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "commitHash": "703bd9caab50b139428cea1aaff9974ebee5742e",
-                    "repositoryUrl": "https://github.com/google/googletest"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "other",
-                "other": {
-                    "name": "Half",
-                    "version": "2.1.0",
-                    "downloadUrl": "https://sourceforge.net/projects/half/files/half/2.1.0/half-2.1.0.zip/download"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "nuget",
-                "nuget": {
-                    "name": "WinPixEventRuntime",
-                    "version": "1.0.220124001"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "commitHash": "f54b0e47a08782a6131cc3d60f94d038fa6e0a51",
-                    "repositoryUrl": "https://github.com/Tencent/rapidjson"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "commitHash": "2e225973d6c2ecf17fb4d376ddbeedb6db7dd82f",
-                    "repositoryUrl": "https://github.com/Microsoft/wil"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "nuget",
-                "nuget": {
-                    "name": "Microsoft.ML.OnnxRuntime.DirectML",
-                    "version": "1.12.1"
-                }
-            }
-        },
-    ],
-    "Version": 1
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "302302b30839505703d37fb82f536c53cf9172fa",
+          "repositoryUrl": "https://github.com/jarro2783/cxxopts"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "nuget",
+        "nuget": {
+          "name": "Microsoft.Direct3D.D3D12",
+          "version": "1.606.3"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "nuget",
+        "nuget": {
+          "name": "Microsoft.AI.DirectML",
+          "version": "1.9.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "DirectX Shader Compiler",
+          "version": "2022_07_18",
+          "downloadUrl": "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2207/dxc_2022_07_18.zip"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "da7aedbc4a81e9c3bbc80bcface65c91e62fd205",
+          "repositoryUrl": "https://github.com/microsoft/DirectX-Headers"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "7bdf0628b1276379886c7f6dda2cef2b3b374f0b",
+          "repositoryUrl": "https://github.com/fmtlib/fmt"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "c1cbb41b428f15e53454682a45f03ea31f1da0a7",
+          "repositoryUrl": "https://github.com/microsoft/GSL"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "703bd9caab50b139428cea1aaff9974ebee5742e",
+          "repositoryUrl": "https://github.com/google/googletest"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "Half",
+          "version": "2.1.0",
+          "downloadUrl": "https://sourceforge.net/projects/half/files/half/2.1.0/half-2.1.0.zip/download"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "nuget",
+        "nuget": {
+          "name": "WinPixEventRuntime",
+          "version": "1.0.220124001"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "f54b0e47a08782a6131cc3d60f94d038fa6e0a51",
+          "repositoryUrl": "https://github.com/Tencent/rapidjson"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "2e225973d6c2ecf17fb4d376ddbeedb6db7dd82f",
+          "repositoryUrl": "https://github.com/Microsoft/wil"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "nuget",
+        "nuget": {
+          "name": "Microsoft.ML.OnnxRuntime.DirectML",
+          "version": "1.12.1"
+        }
+      }
+    }
+  ],
+  "Version": 1
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,42 +1,42 @@
 {
-    "Registrations":[
-       {
-          "component":{
-             "type":"git",
-             "git":{
-                "commitHash":"5f296bbef998e75721818d6b336264ae10f4a77d",
-                "repositoryUrl":"https://github.com/tensorflow/models"
-             }
-          }
-       },
-       {
-          "component":{
-             "type":"git",
-             "git":{
-                "commitHash":"f13555462e835409480829f8fdacac96835161e5",
-                "repositoryUrl":"https://github.com/vonclites/squeezenet"
-             }
-          }
-       },
-       {
-          "component":{
-             "type":"git",
-             "git":{
-                "commitHash":"65294d5dc1794b325db5a37b2ed02773ca5bf839",
-                "repositoryUrl":"https://github.com/zzh8829/yolov3-tf2"
-             }
-          }
-       },
-       {
-         "component":{
-            "type":"git",
-            "git":{
-               "commitHash":"1be31704c9c690929e4f6e6d950f40755ef2dcdc",
-               "repositoryUrl":"https://github.com/ultralytics/yolov3"
-            }
-         }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "5f296bbef998e75721818d6b336264ae10f4a77d",
+          "repositoryUrl": "https://github.com/tensorflow/models"
+        }
       }
-    ],
-    "Version":1
- }
- 
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "f13555462e835409480829f8fdacac96835161e5",
+          "repositoryUrl": "https://github.com/vonclites/squeezenet"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "65294d5dc1794b325db5a37b2ed02773ca5bf839",
+          "repositoryUrl": "https://github.com/zzh8829/yolov3-tf2"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "1be31704c9c690929e4f6e6d950f40755ef2dcdc",
+          "repositoryUrl": "https://github.com/ultralytics/yolov3"
+        }
+      }
+    }
+  ],
+  "Version": 1
+}


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.