### PR TITLE
DxDispatch: ONNX free dim overrides by denotation

### DIFF
--- a/DxDispatch/src/dxdispatch/CommandLineArgs.h
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.h
@@ -19,7 +19,8 @@ public:
     std::optional<uint32_t> TimeToRunInMilliseconds() const { return m_timeToRunInMilliseconds; }
     D3D12_COMMAND_LIST_TYPE CommandListType() const { return m_commandListType; }
     PixCaptureType GetPixCaptureType() const { return m_pixCaptureType; }
-    gsl::span<const std::pair<std::string, uint32_t>> GetOnnxFreeDimensionOverrides() const { return m_freeDimensionOverrides; }
+    gsl::span<const std::pair<std::string, uint32_t>> GetOnnxFreeDimensionNameOverrides() const { return m_freeDimensionNameOverrides; }
+    gsl::span<const std::pair<std::string, uint32_t>> GetOnnxFreeDimensionDenotationOverrides() const { return m_freeDimensionDenotationOverrides; }
 
 private:
     bool m_showAdapters = false;
@@ -34,6 +35,11 @@ private:
     D3D12_COMMAND_LIST_TYPE m_commandListType = D3D12_COMMAND_LIST_TYPE_COMPUTE;
     PixCaptureType m_pixCaptureType = PixCaptureType::Manual;
 
-    // [onnx models] Overrides for free dimensions. First value in pair the name, second value is the dimension size.
-    std::vector<std::pair<std::string, uint32_t>> m_freeDimensionOverrides;
+    // [onnx models] Overrides for free dimensions by name. 
+    // The first value in the pair is the name, and the second value is the dimension size.
+    std::vector<std::pair<std::string, uint32_t>> m_freeDimensionNameOverrides;
+
+    // [onnx models] Overrides for free dimensions by denotation. 
+    // The first value in the pair is the denotation, and the second value is the dimension size.
+    std::vector<std::pair<std::string, uint32_t>> m_freeDimensionDenotationOverrides;
 };

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -94,6 +94,8 @@ Device::Device(IAdapter* adapter, bool debugLayersEnabled, D3D12_COMMAND_LIST_TY
 
 Device::~Device()
 {
+    // Intentionally leak d3d12 module to avoid order-of-destruction issues with PIX wrapper.
+    m_d3dModule.release();
 }
 
 ComPtr<ID3D12Resource> Device::CreateDefaultBuffer(

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -7,11 +7,17 @@ using Microsoft::WRL::ComPtr;
 static const GUID PIX_EVAL_CAPTURABLE_WORK_GUID =
 { 0x59da69, 0xb561, 0x43d9, { 0xa3, 0x9b, 0x33, 0x55, 0x7, 0x4b, 0x10, 0x82 } };
 
-Device::Device(IAdapter* adapter, bool debugLayersEnabled, D3D12_COMMAND_LIST_TYPE commandListType, std::unique_ptr<PixCaptureHelper> pixCaptureHelper) : m_pixCaptureHelper(std::move(pixCaptureHelper))
+Device::Device(
+    IAdapter* adapter, 
+    bool debugLayersEnabled, 
+    D3D12_COMMAND_LIST_TYPE commandListType, 
+    std::shared_ptr<PixCaptureHelper> pixCaptureHelper,
+    std::shared_ptr<D3d12Module> d3dModule,
+    std::shared_ptr<DmlModule> dmlModule
+    ) : m_pixCaptureHelper(std::move(pixCaptureHelper)),
+        m_d3dModule(std::move(d3dModule)),
+        m_dmlModule(std::move(dmlModule))
 {
-    m_d3dModule = std::make_unique<D3d12Module>();
-    m_dmlModule = std::make_unique<DmlModule>();
-
     DML_CREATE_DEVICE_FLAGS dmlCreateDeviceFlags = DML_CREATE_DEVICE_FLAG_NONE;
 
 #ifdef _GAMING_XBOX
@@ -94,8 +100,6 @@ Device::Device(IAdapter* adapter, bool debugLayersEnabled, D3D12_COMMAND_LIST_TY
 
 Device::~Device()
 {
-    // Intentionally leak d3d12 module to avoid order-of-destruction issues with PIX wrapper.
-    m_d3dModule.release();
 }
 
 ComPtr<ID3D12Resource> Device::CreateDefaultBuffer(

--- a/DxDispatch/src/dxdispatch/Device.h
+++ b/DxDispatch/src/dxdispatch/Device.h
@@ -7,7 +7,14 @@
 class Device
 {
 public:
-    Device(IAdapter* adapter, bool debugLayersEnabled, D3D12_COMMAND_LIST_TYPE commandListType, std::unique_ptr<PixCaptureHelper> pixCaptureHelper);
+    Device(
+        IAdapter* adapter, 
+        bool debugLayersEnabled, 
+        D3D12_COMMAND_LIST_TYPE commandListType, 
+        std::shared_ptr<PixCaptureHelper> pixCaptureHelper,
+        std::shared_ptr<D3d12Module> d3dModule,
+        std::shared_ptr<DmlModule> dmlModule
+        );
     ~Device();
 
     D3d12Module* D3DModule() { return m_d3dModule.get(); }
@@ -69,13 +76,13 @@ private:
     void EnsureDxcInterfaces();
 
 private:
-    std::unique_ptr<PixCaptureHelper> m_pixCaptureHelper;
-    std::unique_ptr<D3d12Module> m_d3dModule;
+    std::shared_ptr<PixCaptureHelper> m_pixCaptureHelper;
+    std::shared_ptr<D3d12Module> m_d3dModule;
     Microsoft::WRL::ComPtr<ID3D12Device8> m_d3d;
 #ifndef _GAMING_XBOX
     Microsoft::WRL::ComPtr<ID3D12InfoQueue> m_infoQueue;
 #endif
-    std::unique_ptr<DmlModule> m_dmlModule;
+    std::shared_ptr<DmlModule> m_dmlModule;
     Microsoft::WRL::ComPtr<IDMLDevice1> m_dml;
     Microsoft::WRL::ComPtr<IDMLCommandRecorder> m_commandRecorder;
     Microsoft::WRL::ComPtr<ID3D12CommandQueue> m_queue;

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -94,9 +94,14 @@ void OnnxDispatchable::Initialize()
     sessionOptions.DisableMemPattern();
     sessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_EXTENDED); // Note ORT_ENABLE_BASIC is useful for debugging.
  
-    for (auto& freeDimOverride : m_args.GetOnnxFreeDimensionOverrides())
+    for (auto& freeDimOverride : m_args.GetOnnxFreeDimensionNameOverrides())
     {
-        ortApi.AddFreeDimensionOverrideByName(sessionOptions, freeDimOverride.first.c_str(), freeDimOverride.second);
+        Ort::ThrowOnError(ortApi.AddFreeDimensionOverrideByName(sessionOptions, freeDimOverride.first.c_str(), freeDimOverride.second));
+    }
+
+    for (auto& freeDimOverride : m_args.GetOnnxFreeDimensionDenotationOverrides())
+    {
+        Ort::ThrowOnError(ortApi.AddFreeDimensionOverride(sessionOptions, freeDimOverride.first.c_str(), freeDimOverride.second));
     }
 
     const OrtDmlApi* ortDmlApi;

--- a/DxDispatch/src/dxdispatch/main.cpp
+++ b/DxDispatch/src/dxdispatch/main.cpp
@@ -89,7 +89,8 @@ int main(int argc, char** argv)
                 device->DML(), 
                 device->GetCommandQueue(),
                 args.ModelPath(), 
-                args.GetOnnxFreeDimensionOverrides()
+                args.GetOnnxFreeDimensionNameOverrides(),
+                args.GetOnnxFreeDimensionDenotationOverrides()
             );
 #endif
         }

--- a/DxDispatch/src/model/OnnxParsers.cpp
+++ b/DxDispatch/src/model/OnnxParsers.cpp
@@ -79,7 +79,8 @@ Model OnnxParsers::ParseModel(
     IDMLDevice* device,
     ID3D12CommandQueue* queue,
     const std::filesystem::path& filePath, 
-    gsl::span<const std::pair<std::string, uint32_t>> freeDimOverrides)
+    gsl::span<const std::pair<std::string, uint32_t>> freeDimNameOverrides,
+    gsl::span<const std::pair<std::string, uint32_t>> freeDimDenotationOverrides)
 {
     const OrtApi& ortApi = Ort::GetApi();
 
@@ -88,9 +89,14 @@ Model OnnxParsers::ParseModel(
     sessionOptions.DisableMemPattern();
     sessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
 
-    for (auto& freeDimOverride : freeDimOverrides)
+    for (auto& freeDimOverride : freeDimNameOverrides)
     {
-        ortApi.AddFreeDimensionOverrideByName(sessionOptions, freeDimOverride.first.c_str(), freeDimOverride.second);
+        Ort::ThrowOnError(ortApi.AddFreeDimensionOverrideByName(sessionOptions, freeDimOverride.first.c_str(), freeDimOverride.second));
+    }
+
+    for (auto& freeDimOverride : freeDimDenotationOverrides)
+    {
+        Ort::ThrowOnError(ortApi.AddFreeDimensionOverride(sessionOptions, freeDimOverride.first.c_str(), freeDimOverride.second));
     }
 
     const OrtDmlApi* ortDmlApi;

--- a/DxDispatch/src/model/OnnxParsers.h
+++ b/DxDispatch/src/model/OnnxParsers.h
@@ -17,5 +17,6 @@ namespace OnnxParsers
         IDMLDevice* device,
         ID3D12CommandQueue* queue,
         const std::filesystem::path& filePath, 
-        gsl::span<const std::pair<std::string, uint32_t>> freeDimOverrides);
+        gsl::span<const std::pair<std::string, uint32_t>> freeDimNameOverrides,
+        gsl::span<const std::pair<std::string, uint32_t>> freeDimDenotationOverrides);
 }


### PR DESCRIPTION
Adds the option to override free dimensions by both name and denotation.