### PR TITLE
DxDispatch: fix ONNX models with dynamic output shapes

### DIFF
--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -118,7 +118,7 @@ void OnnxDispatchable::Bind(const Bindings& bindings)
     m_ioBindings->ClearBoundOutputs();
     m_tensors.clear();
     m_tensorWrappers.clear();
-
+    m_memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
     Ort::MemoryInfo memoryInformation("DML", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
     Ort::Allocator deviceAllocator(*m_session, memoryInformation);
 
@@ -177,7 +177,9 @@ void OnnxDispatchable::Bind(const Bindings& bindings)
             }
             else
             {
-                m_ioBindings->BindOutput(tensorName.c_str(), *tensor);
+                // TODO: if no binding, let the EP allocate on the fly.
+                m_ioBindings->BindOutput(tensorName.c_str(), *m_memoryInfo);
+                //m_ioBindings->BindOutput(tensorName.c_str(), *tensor);
             }
         }
     }

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -116,64 +116,78 @@ void OnnxDispatchable::Bind(const Bindings& bindings)
 {
     m_ioBindings->ClearBoundInputs();
     m_ioBindings->ClearBoundOutputs();
-    m_inputTensors.clear();
+    m_tensors.clear();
     m_tensorWrappers.clear();
-    m_memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+
     Ort::MemoryInfo memoryInformation("DML", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemType::OrtMemTypeDefault);
     Ort::Allocator deviceAllocator(*m_session, memoryInformation);
 
     auto inputCount = m_session->GetInputCount();
-    m_inputTensors.resize(inputCount);
+    auto outputCount = m_session->GetOutputCount();
 
-    // Bind input tensors.
-    for (size_t tensorIndex = 0; tensorIndex < inputCount; ++tensorIndex)
+    for (int bindingPass = 0; bindingPass < 2; ++bindingPass)
     {
-        std::string tensorName = OnnxParsers::GetTensorName(tensorIndex, *m_session, /*isInputTensor*/true);
-        Ort::TypeInfo typeInfo = m_session->GetInputTypeInfo(tensorIndex);
-        if (typeInfo.GetONNXType() != ONNXType::ONNX_TYPE_TENSOR)
+        const bool isInputTensor = (bindingPass == 0);
+        const size_t tensorCount = isInputTensor ? inputCount : outputCount;
+
+        for (size_t tensorIndex = 0; tensorIndex < tensorCount; ++tensorIndex)
         {
-            throw std::runtime_error(fmt::format("Unknown binding type for '{}'", tensorName));
+            std::string tensorName = OnnxParsers::GetTensorName(tensorIndex, *m_session, isInputTensor);
+
+            // Input tensors must be always be bound. Outputs are optional.
+            if (isInputTensor || bindings.find(tensorName) != bindings.end())
+            {
+                Ort::TypeInfo typeInfo = isInputTensor ? m_session->GetInputTypeInfo(tensorIndex) : m_session->GetOutputTypeInfo(tensorIndex);
+                if (typeInfo.GetONNXType() != ONNXType::ONNX_TYPE_TENSOR)
+                {
+                    throw std::runtime_error(fmt::format("Unknown binding type for '{}'", tensorName));
+                }
+
+                Ort::Unowned<Ort::TensorTypeAndShapeInfo> shapeInfo = typeInfo.GetTensorTypeAndShapeInfo();
+                const ONNXTensorElementDataType tensorDataType = shapeInfo.GetElementType();
+                if (!OnnxParsers::IsSupportedOnnxTensorElementDataType(tensorDataType))
+                {
+                    throw std::runtime_error("Unsupported tensor data type");
+                }
+
+                // Convert free dimensions (-1) to their minimum positive size (1).
+                std::vector<int64_t> tensorShape = shapeInfo.GetShape();
+                for (auto& dim : tensorShape)
+                {
+                    dim = std::abs(dim);
+                }
+
+                auto resource = GetResourceFromModelBinding(tensorName, bindings);
+
+                // Create an ORT tensor from the existing D3D resource.
+                Microsoft::WRL::ComPtr<IUnknown> resourceWrapper;
+                m_tensors.emplace_back(CreateTensorFromResource(
+                    m_ortDmlApi,
+                    memoryInformation,
+                    resource,
+                    tensorShape,
+                    tensorDataType,
+                    &resourceWrapper));
+
+                m_tensorWrappers.push_back(std::move(resourceWrapper));
+
+                // Bind the tensor.
+                if (isInputTensor)
+                {
+                    m_ioBindings->BindInput(tensorName.c_str(), m_tensors.back());
+                }
+                else
+                {
+                    m_ioBindings->BindOutput(tensorName.c_str(), m_tensors.back());
+                }
+            }
+            else
+            {
+                // Let the execution provider allocate the output.
+                assert(!isInputTensor);
+                m_ioBindings->BindOutput(tensorName.c_str(), memoryInformation);
+            }
         }
-
-        Ort::Unowned<Ort::TensorTypeAndShapeInfo> shapeInfo = typeInfo.GetTensorTypeAndShapeInfo();
-        const ONNXTensorElementDataType tensorDataType = shapeInfo.GetElementType();
-        if (!OnnxParsers::IsSupportedOnnxTensorElementDataType(tensorDataType))
-        {
-            throw std::runtime_error("Unsupported tensor data type");
-        }
-
-        // Convert free dimensions (-1) to their minimum positive size (1).
-        std::vector<int64_t> tensorShape = shapeInfo.GetShape();
-        for (auto& dim : tensorShape)
-        {
-            dim = std::abs(dim);
-        }
-
-        auto resource = GetResourceFromModelBinding(tensorName, bindings);
-
-        std::optional<Ort::Value>& tensor = m_inputTensors[tensorIndex];
-
-        // Create an ORT tensor from the existing D3D resource.
-        Microsoft::WRL::ComPtr<IUnknown> resourceWrapper;
-        tensor = CreateTensorFromResource(
-            m_ortDmlApi, 
-            memoryInformation, 
-            resource,
-            tensorShape,
-            tensorDataType,
-            &resourceWrapper);
-
-        m_tensorWrappers.push_back(std::move(resourceWrapper));
-
-        // Bind the tensor.
-        m_ioBindings->BindInput(tensorName.c_str(), *tensor);
-    }
-
-    // Bind outputs by name only; let the execution provider allocate the output resource.
-    for (size_t tensorIndex = 0; tensorIndex < m_session->GetOutputCount(); ++tensorIndex)
-    {
-        std::string tensorName = OnnxParsers::GetTensorName(tensorIndex, *m_session, /*isInputTensor*/false);
-        m_ioBindings->BindOutput(tensorName.c_str(), *m_memoryInfo);
     }
 }
 
@@ -182,6 +196,4 @@ void OnnxDispatchable::Dispatch(const Model::DispatchCommand& args)
     Ort::RunOptions runOptions;
     m_session->Run(runOptions, *m_ioBindings);
     m_ioBindings->SynchronizeOutputs();
-
-    // TODO: need to copy to model output resource if one is bound.
 }

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.h
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.h
@@ -23,9 +23,8 @@ private:
     std::optional<Ort::Session> m_session;
     const OrtDmlApi* m_ortDmlApi = nullptr;
     const CommandLineArgs& m_args;
-    std::optional<Ort::MemoryInfo> m_memoryInfo;
 
     std::optional<Ort::IoBinding> m_ioBindings;
-    std::vector<std::optional<Ort::Value>> m_inputTensors;
+    std::vector<Ort::Value> m_tensors;
     std::vector<Microsoft::WRL::ComPtr<IUnknown>> m_tensorWrappers;
 };

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.h
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.h
@@ -23,6 +23,7 @@ private:
     std::optional<Ort::Session> m_session;
     const OrtDmlApi* m_ortDmlApi = nullptr;
     const CommandLineArgs& m_args;
+    std::optional<Ort::MemoryInfo> m_memoryInfo;
 
     std::optional<Ort::IoBinding> m_ioBindings;
     std::vector<std::optional<Ort::Value>> m_tensors;

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.h
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.h
@@ -26,6 +26,6 @@ private:
     std::optional<Ort::MemoryInfo> m_memoryInfo;
 
     std::optional<Ort::IoBinding> m_ioBindings;
-    std::vector<std::optional<Ort::Value>> m_tensors;
+    std::vector<std::optional<Ort::Value>> m_inputTensors;
     std::vector<Microsoft::WRL::ComPtr<IUnknown>> m_tensorWrappers;
 };

--- a/DxDispatch/src/model/OnnxParsers.cpp
+++ b/DxDispatch/src/model/OnnxParsers.cpp
@@ -113,20 +113,9 @@ Model OnnxParsers::ParseModel(
     BucketAllocator allocator;
 
     // Create resources.
-    std::vector<Model::ResourceDesc> resources(inputCount + outputCount);
+    std::vector<Model::ResourceDesc> resources;
     Model::Bindings bindings;
 
-    // DxDispatch requires pre-allocated input and output resources that are bound at execution time.
-    // However, some ONNX models have output shapes that aren't fully known until the model is exected.
-    // As a workaround, this function will run the model once to determine the necessary size of output
-    // resources. This is inefficient (and unfortunate), and perhaps in the future there will be a way 
-    // to reflect the output buffer sizes without actually running the ONNX model.
-    Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-    std::vector<Ort::Value> inputData;
-    std::vector<const char*> inputNames(inputCount);
-    std::vector<const char*> outputNames(outputCount);
-
-    size_t resourceIndex = 0;
     for (int bindingPass = 0; bindingPass < 2; ++bindingPass)
     {
         const bool isInputTensor = (bindingPass == 0);
@@ -138,7 +127,7 @@ Model OnnxParsers::ParseModel(
 
             resourceDesc.name = OnnxParsers::GetTensorName(tensorIndex, session, isInputTensor);
             Ort::TypeInfo typeInfo = isInputTensor ? session.GetInputTypeInfo(tensorIndex) : session.GetOutputTypeInfo(tensorIndex);
-
+            
             if (typeInfo.GetONNXType() != ONNXType::ONNX_TYPE_TENSOR)
             {
                 throw std::invalid_argument("Unsupported non-tensor input/output in ONNX model");
@@ -153,17 +142,13 @@ Model OnnxParsers::ParseModel(
 
             uint64_t elementCount = 1;
             std::vector<uint32_t> sizes;
-            std::vector<int64_t> sizesInt64;
             for (auto dim : shapeInfo.GetShape())
             {
                 // std::abs to convert free dimensions (-1) to their minimum size of 1.
                 sizes.push_back(std::abs(dim));
-                sizesInt64.push_back(std::abs(dim));
                 elementCount *= sizes.back();
             }
 
-            // NOTE: the output buffer size may be inaccurate here. It will be rewritten
-            // after OrtSession::Run.
             Model::BufferDesc bufferDesc = {};
             bufferDesc.initialValuesDataType = ConvertOnnxTensorDataType(tensorDataType);
             bufferDesc.sizeInBytes = DMLCalcBufferTensorSize(
@@ -180,58 +165,8 @@ Model OnnxParsers::ParseModel(
                 OnnxTensorDataTypeSize(tensorDataType)
             }};
 
-            resources[resourceIndex] = std::move(resourceDesc);
-
-            if (isInputTensor)
-            {
-                inputNames[tensorIndex] = resources[resourceIndex].name.c_str();
-
-                // The default allocator doesn't have to be freed.
-                auto allocator = static_cast<OrtAllocator*>(Ort::AllocatorWithDefaultOptions());
-                inputData.emplace_back(Ort::Value::CreateTensor(allocator, sizesInt64.data(), sizesInt64.size(), tensorDataType));
-            }
-            else
-            {
-                outputNames[tensorIndex] = resources[resourceIndex].name.c_str();
-            }
-
-            resourceIndex++;
+            resources.emplace_back(std::move(resourceDesc));
         }
-    }
-
-    // Run the model to get true output sizes, then overwrite the resource descs.
-    auto outputValues = session.Run(Ort::RunOptions{ nullptr }, inputNames.data(), inputData.data(), inputNames.size(), outputNames.data(), outputNames.size());
-    for (size_t outputIndex = 0; outputIndex < outputCount; ++outputIndex)
-    {
-        auto shapeInfo = outputValues[outputIndex].GetTypeInfo().GetTensorTypeAndShapeInfo();
-        auto tensorDataType = shapeInfo.GetElementType();
-
-        uint64_t elementCount = 1;
-        std::vector<uint32_t> sizes;
-        for (auto dim : shapeInfo.GetShape())
-        {
-            assert(dim >= 1);
-            sizes.push_back(std::abs(dim));
-            elementCount *= sizes.back();
-        }
-
-        Model::BufferDesc bufferDesc = {};
-        bufferDesc.initialValuesDataType = ConvertOnnxTensorDataType(tensorDataType);
-        bufferDesc.sizeInBytes = DMLCalcBufferTensorSize(
-            bufferDesc.initialValuesDataType,
-            sizes.size(),
-            sizes.data(),
-            nullptr
-        );
-
-        size_t resourceIndex = outputIndex + inputCount;
-        resources[resourceIndex].value = std::move(bufferDesc);
-
-        bindings[resources[resourceIndex].name] = { Model::BufferBindingSource{
-            resources[resourceIndex].name,
-            elementCount,
-            OnnxTensorDataTypeSize(tensorDataType)
-        }};
     }
 
     // Create dispatchable.

--- a/DxDispatch/src/model/OnnxParsers.cpp
+++ b/DxDispatch/src/model/OnnxParsers.cpp
@@ -169,7 +169,7 @@ Model OnnxParsers::ParseModel(
                 );
 
                 resourceDesc.value = bufferDesc;
-                bindings[resourceDesc.name] = { Model::BufferBindingSource{
+                bindings[resourceDesc.name] = {Model::BufferBindingSource{
                     resourceDesc.name,
                     elementCount,
                     OnnxTensorDataTypeSize(tensorDataType)

--- a/DxDispatch/src/model/OnnxParsers.cpp
+++ b/DxDispatch/src/model/OnnxParsers.cpp
@@ -133,37 +133,47 @@ Model OnnxParsers::ParseModel(
                 throw std::invalid_argument("Unsupported non-tensor input/output in ONNX model");
             }
 
-            Ort::Unowned<Ort::TensorTypeAndShapeInfo> shapeInfo = typeInfo.GetTensorTypeAndShapeInfo();
-            const ONNXTensorElementDataType tensorDataType = shapeInfo.GetElementType();
-            if (!OnnxParsers::IsSupportedOnnxTensorElementDataType(tensorDataType))
+            // DxDispatch's execution model assumes that all resources can be pre-allocated and
+            // bound to a dispatchable before its executed. While it's possible to pre-allocate 
+            // ONNX input tensors, the output tensors might not be fully known until after the 
+            // execution provider manipulates and executes the ONNX model. Consequently, ONNX
+            // dispatchables have special logic to let the execution provider allocate outputs
+            // if the user doesn't explicitly bind something in a JSON model (i.e. not the
+            // case here since the inputs are generated).
+            if (isInputTensor)
             {
-                throw std::invalid_argument("Unsupported tensor data type in ONNX model");
+                Ort::Unowned<Ort::TensorTypeAndShapeInfo> shapeInfo = typeInfo.GetTensorTypeAndShapeInfo();
+                const ONNXTensorElementDataType tensorDataType = shapeInfo.GetElementType();
+                if (!OnnxParsers::IsSupportedOnnxTensorElementDataType(tensorDataType))
+                {
+                    throw std::invalid_argument("Unsupported tensor data type in ONNX model");
+                }
+
+                uint64_t elementCount = 1;
+                std::vector<uint32_t> sizes;
+                for (auto dim : shapeInfo.GetShape())
+                {
+                    // std::abs to convert free dimensions (-1) to their minimum size of 1.
+                    sizes.push_back(std::abs(dim));
+                    elementCount *= sizes.back();
+                }
+
+                Model::BufferDesc bufferDesc = {};
+                bufferDesc.initialValuesDataType = ConvertOnnxTensorDataType(tensorDataType);
+                bufferDesc.sizeInBytes = DMLCalcBufferTensorSize(
+                    bufferDesc.initialValuesDataType,
+                    sizes.size(),
+                    sizes.data(),
+                    nullptr
+                );
+
+                resourceDesc.value = bufferDesc;
+                bindings[resourceDesc.name] = { Model::BufferBindingSource{
+                    resourceDesc.name,
+                    elementCount,
+                    OnnxTensorDataTypeSize(tensorDataType)
+                }};
             }
-
-            uint64_t elementCount = 1;
-            std::vector<uint32_t> sizes;
-            for (auto dim : shapeInfo.GetShape())
-            {
-                // std::abs to convert free dimensions (-1) to their minimum size of 1.
-                sizes.push_back(std::abs(dim));
-                elementCount *= sizes.back();
-            }
-
-            Model::BufferDesc bufferDesc = {};
-            bufferDesc.initialValuesDataType = ConvertOnnxTensorDataType(tensorDataType);
-            bufferDesc.sizeInBytes = DMLCalcBufferTensorSize(
-                bufferDesc.initialValuesDataType,
-                sizes.size(),
-                sizes.data(),
-                nullptr
-            );
-
-            resourceDesc.value = bufferDesc;
-            bindings[resourceDesc.name] = {Model::BufferBindingSource{
-                resourceDesc.name, 
-                elementCount, 
-                OnnxTensorDataTypeSize(tensorDataType)
-            }};
 
             resources.emplace_back(std::move(resourceDesc));
         }

--- a/DxDispatch/src/model/OnnxParsers.cpp
+++ b/DxDispatch/src/model/OnnxParsers.cpp
@@ -134,12 +134,13 @@ Model OnnxParsers::ParseModel(
             }
 
             // DxDispatch's execution model assumes that all resources can be pre-allocated and
-            // bound to a dispatchable before its executed. While it's possible to pre-allocate 
+            // bound to a dispatchable before it is executed. While it's possible to pre-allocate 
             // ONNX input tensors, the output tensors might not be fully known until after the 
-            // execution provider manipulates and executes the ONNX model. Consequently, ONNX
-            // dispatchables have special logic to let the execution provider allocate outputs
-            // if the user doesn't explicitly bind something in a JSON model (i.e. not the
-            // case here since the inputs are generated).
+            // execution provider manipulates and executes the ONNX model. This parsing logic 
+            // leaves the DxDispatch model outputs unbound/unset, which in turn means the ONNX
+            // dispatchable will defer to the execution provider to allocate outputs on the fly.
+            // This behavior is acceptable since we don't care about outputs when parsing ONNX
+            // files directly: the inputs are generated with random/unintialized data.
             if (isInputTensor)
             {
                 Ort::Unowned<Ort::TensorTypeAndShapeInfo> shapeInfo = typeInfo.GetTensorTypeAndShapeInfo();
@@ -173,9 +174,9 @@ Model OnnxParsers::ParseModel(
                     elementCount,
                     OnnxTensorDataTypeSize(tensorDataType)
                 }};
-            }
 
-            resources.emplace_back(std::move(resourceDesc));
+                resources.emplace_back(std::move(resourceDesc));
+            }
         }
     }
 


### PR DESCRIPTION
Fixes an issue in the DxDispatch tool where generated output bindings use shape info from the session that is incorrect. See #276 

Some models have shape info that can't be known until after the model is executed, so there appears to be no way to reliably pre-allocate outputs with the IOBinding API. As a workaround, this change will let the execution provider allocate the output resources rather than providing D3D resources allocated by DxDispatch. This is acceptable because the generated output bindings aren't really used for anything anyway.