### PR TITLE
DxDispatch: switch to debug message callback

### DIFF
--- a/DxDispatch/cmake/d3d12.cmake
+++ b/DxDispatch/cmake/d3d12.cmake
@@ -69,7 +69,7 @@ function(init_d3d12_cache_variables prefix)
 
     # <PREFIX>_D3D12_HEADERS_TAG
     set(${prefix}_D3D12_HEADERS_TAG
-        d49ae12ab350b20468a9667bad700f3227cd3f7a
+        fb9a40f1b8165c848cf49fdb396722af7181ff97
         CACHE STRING "Git commit/tag for headers in the DirectX-Headers repo."
     )
 endfunction()

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -15,7 +15,7 @@ static bool DebugMessageCallback(void* context, void* commandList, DWORD message
     return true;
 }
 #else
-static void DebugMessageCallback(D3D12_MESSAGE_CATEGORY cat, D3D12_MESSAGE_SEVERITY sev, D3D12_MESSAGE_ID id, LPCSTR message, void* context)
+static void __stdcall DebugMessageCallback(D3D12_MESSAGE_CATEGORY cat, D3D12_MESSAGE_SEVERITY sev, D3D12_MESSAGE_ID id, LPCSTR message, void* context)
 {
     LogError(message);
 }

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -9,9 +9,10 @@ static const GUID PIX_EVAL_CAPTURABLE_WORK_GUID =
 
 // Callback to log D3D12/DirectML debug messages.
 #ifdef _GAMING_XBOX
-static void DebugMessageCallback( void* context, void* commandList, DWORD messageId, const CHAR* message)
+static bool DebugMessageCallback(void* context, void* commandList, DWORD messageId, const CHAR* message)
 {
     LogError(message);
+    return true;
 }
 #else
 static void DebugMessageCallback(D3D12_MESSAGE_CATEGORY cat, D3D12_MESSAGE_SEVERITY sev, D3D12_MESSAGE_ID id, LPCSTR message, void* context)
@@ -53,7 +54,7 @@ Device::Device(
 
     THROW_IF_FAILED(D3D12XboxCreateDevice(adapter, &params, IID_GRAPHICS_PPV_ARGS(m_d3d.ReleaseAndGetAddressOf())));
 
-    if (debugLayerEnabled)
+    if (debugLayersEnabled)
     {
         m_d3d->SetDebugCallbackX(DebugMessageCallback, /*context*/nullptr);
     }

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -82,7 +82,7 @@ Device::Device(
             nullptr, 
             &callbackCookie);
     }
-#endif
+#endif // !_GAMING_XBOX
 
     THROW_IF_FAILED(m_d3d->CreateFence(
         0, 

--- a/DxDispatch/src/dxdispatch/Device.h
+++ b/DxDispatch/src/dxdispatch/Device.h
@@ -56,8 +56,6 @@ public:
 
     void DispatchAndWait();
 
-    void PrintDebugLayerMessages();
-    
     void RecordDispatch(IDMLDispatchable* dispatchable, IDMLBindingTable* bindingTable);
 
     void KeepAliveUntilNextCommandListDispatch(Microsoft::WRL::ComPtr<IGraphicsUnknown>&& object)
@@ -80,7 +78,7 @@ private:
     std::shared_ptr<D3d12Module> m_d3dModule;
     Microsoft::WRL::ComPtr<ID3D12Device8> m_d3d;
 #ifndef _GAMING_XBOX
-    Microsoft::WRL::ComPtr<ID3D12InfoQueue> m_infoQueue;
+    Microsoft::WRL::ComPtr<ID3D12InfoQueue1> m_infoQueue;
 #endif
     std::shared_ptr<DmlModule> m_dmlModule;
     Microsoft::WRL::ComPtr<IDMLDevice1> m_dml;

--- a/DxDispatch/src/dxdispatch/Executor.cpp
+++ b/DxDispatch/src/dxdispatch/Executor.cpp
@@ -40,7 +40,6 @@ Executor::Executor(Model& model, std::shared_ptr<Device> device, const CommandLi
         }
     }
     device->DispatchAndWait();
-    device->PrintDebugLayerMessages();
 
     // Create dispatchables.
     for (auto& desc : model.GetDispatchableDescs())
@@ -75,7 +74,6 @@ Executor::Executor(Model& model, std::shared_ptr<Device> device, const CommandLi
                 catch (const std::exception& e)
                 {
                     LogError(fmt::format("Failed to resolve bindings: {}", e.what()));
-                    m_device->PrintDebugLayerMessages();
                     return;
                 }
 
@@ -84,7 +82,6 @@ Executor::Executor(Model& model, std::shared_ptr<Device> device, const CommandLi
         }
         catch(const std::exception& e)
         {
-            device->PrintDebugLayerMessages();
             throw std::invalid_argument(fmt::format("ERROR creating dispatchable '{}': {}", desc.name, e.what()));
         }
     }
@@ -102,7 +99,6 @@ Executor::Executor(Model& model, std::shared_ptr<Device> device, const CommandLi
             }
             catch (const std::exception& e)
             {
-                m_device->PrintDebugLayerMessages();
                 throw std::invalid_argument(fmt::format("ERROR while initializing '{}': {}", dispatchable.first, e.what()));
             }
         }
@@ -138,7 +134,6 @@ void Executor::operator()(const Model::DispatchCommand& command)
     catch (const std::exception& e)
     {
         LogError(fmt::format("Failed to resolve bindings: {}", e.what()));
-        m_device->PrintDebugLayerMessages();
         return;
     }
 
@@ -159,7 +154,6 @@ void Executor::operator()(const Model::DispatchCommand& command)
             catch (const std::exception& e)
             {
                 LogError(fmt::format("ERROR while binding resources: {}\n", e.what()));
-                m_device->PrintDebugLayerMessages();
                 return;
             }
 
@@ -190,7 +184,6 @@ void Executor::operator()(const Model::DispatchCommand& command)
     catch (const std::exception& e)
     {
         LogError(fmt::format("Failed to execute dispatchable: {}", e.what()));
-        m_device->PrintDebugLayerMessages();
         return;
     }
     PIXEndEvent();
@@ -268,7 +261,6 @@ void Executor::operator()(const Model::PrintCommand& command)
     catch (const std::exception& e)
     {
         LogError(fmt::format("Failed to print resource: {}", e.what()));
-        m_device->PrintDebugLayerMessages();
     }
 }
 


### PR DESCRIPTION
The existing `Device::PrintDebugLayerMessages` method is a polling-based approach for printing D3D/DML debug messages. This PR switches to the newer callback-based approach, which means messages will be printed upon being added to the underlying D3D info queue.