### PR TITLE
DxDispatch: option to show more info for loaded dependencies

### DIFF
--- a/DxDispatch/CMakeLists.txt
+++ b/DxDispatch/CMakeLists.txt
@@ -108,6 +108,7 @@ add_executable(
     src/dxdispatch/Logging.cpp
     src/dxdispatch/PixCaptureHelper.cpp
     src/dxdispatch/DxModules.cpp
+    src/dxdispatch/ModuleInfo.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/config.h
 )
 
@@ -123,6 +124,7 @@ set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT dxdispatch)
 
 if(WIN32)
     target_sources(dxdispatch PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/dxdispatch.rc)
+    target_link_libraries(dxdispatch PRIVATE version.lib)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/dxdispatch/dxdispatch.rc.in dxdispatch.rc)
 endif()
 

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -5,20 +5,7 @@
 
 CommandLineArgs::CommandLineArgs(int argc, char** argv)
 {
-        auto banner = fmt::format(R"({} version {}
-  DirectML     : {}
-  D3D12        : {}
-  DXCompiler   : {}
-  PIX          : {}
-  ONNX Runtime : {}
-)",
-        c_projectName, 
-        c_projectVersion,
-        c_directmlConfig,
-        c_d3d12Config,
-        c_dxcompilerConfig,
-        c_pixConfig,
-        c_ortConfig);
+    auto banner = fmt::format(R"({} version {})", c_projectName, c_projectVersion);
     
     cxxopts::Options options(c_projectName, banner);
     options.add_options()
@@ -55,6 +42,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
         (
             "s,show_adapters", 
             "Show all available DirectX adapters", 
+            cxxopts::value<bool>()
+        )
+        (
+            "S,show_dependencies",
+            "Show version info for dependencies including DirectX components",
             cxxopts::value<bool>()
         )
         (
@@ -130,6 +122,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
     if (result.count("show_adapters")) 
     { 
         m_showAdapters = result["show_adapters"].as<bool>(); 
+    }
+
+    if (result.count("show_dependencies"))
+    {
+        m_showDependencies = result["show_dependencies"].as<bool>();
     }
 
     auto queueTypeStr = result["queue_type"].as<std::string>();

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -5,7 +5,20 @@
 
 CommandLineArgs::CommandLineArgs(int argc, char** argv)
 {
-    auto banner = fmt::format(R"({} version {})", c_projectName, c_projectVersion);
+        auto banner = fmt::format(R"({} version {}
+  DirectML     : {}
+  D3D12        : {}
+  DXCompiler   : {}
+  PIX          : {}
+  ONNX Runtime : {}
+)",
+        c_projectName, 
+        c_projectVersion,
+        c_directmlConfig,
+        c_d3d12Config,
+        c_dxcompilerConfig,
+        c_pixConfig,
+        c_ortConfig);
     
     cxxopts::Options options(c_projectName, banner);
     options.add_options()

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.h
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.h
@@ -9,6 +9,7 @@ public:
     CommandLineArgs(int argc, char** argv);
 
     bool ShowAdapters() const { return m_showAdapters; }
+    bool ShowDependencies() const { return m_showDependencies; }
     bool PrintHelp() const { return m_printHelp; }
     bool DebugLayersEnabled() const { return m_debugLayersEnabled; }
     bool ForceDisablePrecompiledShadersOnXbox() const { return m_forceDisablePrecompiledShadersOnXbox; }
@@ -24,6 +25,7 @@ public:
 
 private:
     bool m_showAdapters = false;
+    bool m_showDependencies = false;
     bool m_printHelp = false;
     bool m_debugLayersEnabled = false;
     bool m_forceDisablePrecompiledShadersOnXbox = true;

--- a/DxDispatch/src/dxdispatch/DxModules.cpp
+++ b/DxDispatch/src/dxdispatch/DxModules.cpp
@@ -5,6 +5,13 @@
 #include <dlfcn.h>
 #endif
 
+#if !defined(_GAMING_XBOX) && defined(WIN32)
+// Needed for DX12 agility SDK. Xbox uses DX12.x from the GDK.
+// https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/
+extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = DIRECT3D_AGILITY_SDK_VERSION; }
+extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = DIRECT3D_AGILITY_SDK_PATH; }
+#endif
+
 Module::Module(const char* moduleName)
 {
     if (!moduleName)

--- a/DxDispatch/src/dxdispatch/DxModules.h
+++ b/DxDispatch/src/dxdispatch/DxModules.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ModuleInfo.h"
+
 class Module
 {
 public:
@@ -46,11 +48,10 @@ class D3d12Module : public Module
 {
 public:
 #if defined(_GAMING_XBOX)
+    // Intentionally set to null; D3D12 is dynamically linked for Xbox.
     D3d12Module(const char* moduleName = nullptr);
-#elif defined(WIN32)
-    D3d12Module(const char* moduleName = "d3d12.dll");
 #else
-    D3d12Module(const char* moduleName = "libd3d12.so");
+    D3d12Module(const char* moduleName = c_direct3dModuleName);
 #endif
 
 #ifndef _GAMING_XBOX
@@ -84,13 +85,7 @@ private:
 class DxCoreModule : public Module
 {
 public:
-#if defined(_GAMING_XBOX)
-    DxCoreModule(const char* moduleName = nullptr);
-#elif defined(WIN32)
-    DxCoreModule(const char* moduleName = "dxcore.dll");
-#else
-    DxCoreModule(const char* moduleName = "libdxcore.so");
-#endif
+    DxCoreModule(const char* moduleName = c_dxcoreModuleName);
 
     inline HRESULT CreateAdapterFactory(REFIID riid, void** factory)
     {
@@ -108,11 +103,7 @@ private:
 class DmlModule : public Module
 {
 public:
-#if defined(WIN32)
-    DmlModule(const char* moduleName = "directml.dll");
-#else
-    DmlModule(const char* moduleName = "libdirectml.so");
-#endif
+    DmlModule(const char* moduleName = c_directmlModuleName);
 
     inline HRESULT CreateDevice1(ID3D12Device* d3d12Device, DML_CREATE_DEVICE_FLAGS flags, DML_FEATURE_LEVEL minimumFeatureLevel, REFIID riid, void** device)
     {

--- a/DxDispatch/src/dxdispatch/DxModules.h
+++ b/DxDispatch/src/dxdispatch/DxModules.h
@@ -27,6 +27,12 @@ public:
         return functionPtr(std::forward<Args>(args)...);
     }
 
+#ifdef WIN32
+    HMODULE GetHandle() const { return m_module.get(); }
+#else
+    void* GetHandle() const { return m_module; }
+#endif
+
 protected:
 #ifdef WIN32
     wil::unique_hmodule m_module;

--- a/DxDispatch/src/dxdispatch/ModuleInfo.cpp
+++ b/DxDispatch/src/dxdispatch/ModuleInfo.cpp
@@ -73,10 +73,9 @@ std::optional<ModuleInfo> GetModuleInfo(std::string moduleName)
 
 #else // !_WIN32
 
-ModuleInfo GetModuleInfo(std::string moduleName)
+std::optional<ModuleInfo> GetModuleInfo(std::string moduleName)
 {
-    ModuleInfo moduleInfo = {};
-    return moduleInfo;
+    return std::nullopt;
 }
 
 #endif

--- a/DxDispatch/src/dxdispatch/ModuleInfo.cpp
+++ b/DxDispatch/src/dxdispatch/ModuleInfo.cpp
@@ -1,0 +1,69 @@
+#include "pch.h"
+#include "ModuleInfo.h"
+#include <wil/win32_helpers.h>
+
+#ifdef _WIN32
+
+struct LanguageAndCodePage
+{
+    WORD language;
+    WORD codePage;
+};
+
+ModuleInfo GetModuleInfo(std::string moduleName)
+{
+    // get modules loaded into memory and match with moduleName
+    auto moduleHandle = GetModuleHandleA(moduleName.c_str());
+
+    ModuleInfo moduleInfo = {};
+    moduleInfo.path = wil::GetModuleFileNameW(moduleHandle).get();
+    moduleInfo.version = L"Unknown";
+
+    DWORD versionInfoHandle = 0;
+    auto versionInfoSizeInBytes = GetFileVersionInfoSizeW(moduleInfo.path.data(), &versionInfoHandle);
+    if (versionInfoSizeInBytes)
+    {
+        std::vector<std::byte> versionInfo(versionInfoSizeInBytes);
+        if (GetFileVersionInfoW(moduleInfo.path.data(), versionInfoHandle, versionInfoSizeInBytes, versionInfo.data()))
+        {
+            // Read the list of languages and code pages stored in the file.
+            LanguageAndCodePage* translationData;
+            UINT translationDataSize = 0;
+            if (VerQueryValueW(versionInfo.data(), L"\\VarFileInfo\\Translation", (LPVOID*)&translationData, &translationDataSize))
+            {
+                // Use the en-US language code (1033) if it's not stored in the module.
+                WORD languageCode = translationData->language;
+                if (!languageCode)
+                {
+                    languageCode = 1033;
+                }
+
+                // Query the product version string using the language & codepage.
+                auto query = fmt::format(L"\\StringFileInfo\\{0:04x}{1:04x}\\ProductVersion", languageCode, translationData->codePage);
+
+                LPVOID productVersionStringDataStart = nullptr;
+                UINT productVersionStringDataSizeInChars = 0;
+                if (VerQueryValueW(versionInfo.data(),
+                    query.c_str(),
+                    &productVersionStringDataStart,
+                    &productVersionStringDataSizeInChars))
+                {
+                    moduleInfo.version.resize(productVersionStringDataSizeInChars);
+                    memcpy(moduleInfo.version.data(), productVersionStringDataStart, productVersionStringDataSizeInChars * sizeof(wchar_t));
+                }
+            }
+        }
+    }
+
+    return moduleInfo;
+}
+
+#else
+
+ModuleInfo GetModuleInfo(std::string moduleName)
+{
+    ModuleInfo moduleInfo = {};
+    return moduleInfo;
+}
+
+#endif

--- a/DxDispatch/src/dxdispatch/ModuleInfo.cpp
+++ b/DxDispatch/src/dxdispatch/ModuleInfo.cpp
@@ -77,3 +77,14 @@ ModuleInfo GetModuleInfo(std::string moduleName)
 }
 
 #endif
+
+void PrintModuleInfo(std::string name, const ModuleInfo& loadedModuleInfo, std::string_view configVersion)
+{
+    std::cout << name << ":\n";
+    std::cout << "- Configure Version : " << configVersion << std::endl;
+#if defined(_WIN32) && !defined(_GAMING_XBOX)
+    std::wcout << L"- Loaded Path       : " << loadedModuleInfo.path << std::endl;
+    std::wcout << L"- Loaded Version    : " << loadedModuleInfo.version << std::endl;
+#endif
+    std::cout << std::endl;
+}

--- a/DxDispatch/src/dxdispatch/ModuleInfo.cpp
+++ b/DxDispatch/src/dxdispatch/ModuleInfo.cpp
@@ -19,9 +19,9 @@ struct LanguageAndCodePage
     WORD codePage;
 };
 
-std::optional<ModuleInfo> GetModuleInfo(std::string moduleName)
+std::optional<ModuleInfo> GetModuleInfo(gsl::czstring<> moduleName)
 {
-    auto moduleHandle = GetModuleHandleA(moduleName.c_str());
+    auto moduleHandle = GetModuleHandleA(moduleName);
     if (!moduleHandle)
     {
         return std::nullopt;
@@ -73,14 +73,14 @@ std::optional<ModuleInfo> GetModuleInfo(std::string moduleName)
 
 #else // !_WIN32
 
-std::optional<ModuleInfo> GetModuleInfo(std::string moduleName)
+std::optional<ModuleInfo> GetModuleInfo(gsl::czstring<> moduleName)
 {
     return std::nullopt;
 }
 
 #endif
 
-void PrintModuleInfo(std::string name, const std::optional<ModuleInfo>& loadedModuleInfo, std::string_view configVersion)
+void PrintModuleInfo(std::string_view name, const std::optional<ModuleInfo>& loadedModuleInfo, std::string_view configVersion)
 {
     std::cout << name << ":\n";
     std::cout << "- Configured Version : " << configVersion << std::endl;
@@ -100,17 +100,9 @@ void PrintModuleInfo(std::string name, const std::optional<ModuleInfo>& loadedMo
 
 void PrintDependencies()
 {
-        PrintModuleInfo("DirectML", GetModuleInfo("directml"), c_directmlConfig);
-
-#ifdef _GAMING_XBOX_SCARLETT
-        PrintModuleInfo("D3D12", GetModuleInfo("d3d12_xs"), c_d3d12Config);
-        PrintModuleInfo("DXCompiler", GetModuleInfo("dxcompiler_xs"), c_dxcompilerConfig);
-        PrintModuleInfo("PIX", GetModuleInfo("pixevt"), c_pixConfig);
-#else
-        PrintModuleInfo("D3D12", GetModuleInfo("d3d12core"), c_d3d12Config);
-        PrintModuleInfo("DXCompiler", GetModuleInfo("dxcompiler"), c_dxcompilerConfig);
-        PrintModuleInfo("PIX", GetModuleInfo("winpixeventruntime"), c_pixConfig);
-#endif
-
-        PrintModuleInfo("ONNX Runtime", GetModuleInfo("onnxruntime"), c_ortConfig);
+        PrintModuleInfo("DirectML", GetModuleInfo(c_directmlModuleName), c_directmlConfig);
+        PrintModuleInfo("D3D12", GetModuleInfo(c_direct3dCoreModuleName), c_d3d12Config);
+        PrintModuleInfo("DXCompiler", GetModuleInfo(c_dxcompilerModuleName), c_dxcompilerConfig);
+        PrintModuleInfo("PIX", GetModuleInfo(c_pixModuleName), c_pixConfig);
+        PrintModuleInfo("ONNX Runtime", GetModuleInfo(c_ortModuleName), c_ortConfig);
 }

--- a/DxDispatch/src/dxdispatch/ModuleInfo.cpp
+++ b/DxDispatch/src/dxdispatch/ModuleInfo.cpp
@@ -1,8 +1,16 @@
 #include "pch.h"
 #include "ModuleInfo.h"
-#include <wil/win32_helpers.h>
 
 #ifdef _WIN32
+
+#ifdef _GAMING_XBOX
+// QueryUnbiasedInterruptTime is not declared in WINAPI_PARTITION_GAMES
+// Undefining _APISETREALTIME_ will avoid a few win32_helpers declarations
+// that won't work in WINAPI_PARTITION_GAMES.
+#undef _APISETREALTIME_
+#endif
+
+#include <wil/win32_helpers.h>
 
 struct LanguageAndCodePage
 {
@@ -19,6 +27,7 @@ ModuleInfo GetModuleInfo(std::string moduleName)
     moduleInfo.path = wil::GetModuleFileNameW(moduleHandle).get();
     moduleInfo.version = L"Unknown";
 
+#ifndef _GAMING_XBOX
     DWORD versionInfoHandle = 0;
     auto versionInfoSizeInBytes = GetFileVersionInfoSizeW(moduleInfo.path.data(), &versionInfoHandle);
     if (versionInfoSizeInBytes)
@@ -54,11 +63,12 @@ ModuleInfo GetModuleInfo(std::string moduleName)
             }
         }
     }
+#endif
 
     return moduleInfo;
 }
 
-#else
+#else // !_WIN32
 
 ModuleInfo GetModuleInfo(std::string moduleName)
 {

--- a/DxDispatch/src/dxdispatch/ModuleInfo.h
+++ b/DxDispatch/src/dxdispatch/ModuleInfo.h
@@ -1,11 +1,37 @@
 #pragma once
 
+#if defined(_GAMING_XBOX_SCARLETT)
+    constexpr const char* c_directmlModuleName = "directml.dll";
+    constexpr const char* c_direct3dModuleName = "d3d12_xs.dll";
+    constexpr const char* c_direct3dCoreModuleName = c_direct3dModuleName;
+    constexpr const char* c_dxcoreModuleName = nullptr;
+    constexpr const char* c_dxcompilerModuleName = "dxcompiler_xs.dll";
+    constexpr const char* c_pixModuleName = "pixevt.dll";
+    constexpr const char* c_ortModuleName = "onnxruntime.dll";
+#elif defined(WIN32)
+    constexpr const char* c_directmlModuleName = "directml.dll";
+    constexpr const char* c_direct3dModuleName = "d3d12.dll";
+    constexpr const char* c_direct3dCoreModuleName = "d3d12core.dll";
+    constexpr const char* c_dxcoreModuleName = "dxcore.dll";
+    constexpr const char* c_dxcompilerModuleName = "dxcompiler.dll";
+    constexpr const char* c_pixModuleName = "winpixeventruntime.dll";
+    constexpr const char* c_ortModuleName = "onnxruntime.dll";
+#else
+    constexpr const char* c_directmlModuleName = "libdirectml.so";
+    constexpr const char* c_direct3dModuleName = "libd3d12.so";
+    constexpr const char* c_direct3dCoreModuleName = c_direct3dModuleName;
+    constexpr const char* c_dxcoreModuleName = "libdxcore.so";
+    constexpr const char* c_dxcompilerModuleName = nullptr;
+    constexpr const char* c_pixModuleName = nullptr;
+    constexpr const char* c_ortModuleName = nullptr;
+#endif
+
 struct ModuleInfo
 {
     std::wstring path;
     std::wstring version;
 };
 
-std::optional<ModuleInfo> GetModuleInfo(std::string moduleName);
+std::optional<ModuleInfo> GetModuleInfo(gsl::czstring<> moduleName);
 
 void PrintDependencies();

--- a/DxDispatch/src/dxdispatch/ModuleInfo.h
+++ b/DxDispatch/src/dxdispatch/ModuleInfo.h
@@ -6,6 +6,6 @@ struct ModuleInfo
     std::wstring version;
 };
 
-ModuleInfo GetModuleInfo(std::string moduleName);
+std::optional<ModuleInfo> GetModuleInfo(std::string moduleName);
 
-void PrintModuleInfo(std::string name, const ModuleInfo& loadedModuleInfo, std::string_view configVersion);
+void PrintDependencies();

--- a/DxDispatch/src/dxdispatch/ModuleInfo.h
+++ b/DxDispatch/src/dxdispatch/ModuleInfo.h
@@ -7,3 +7,5 @@ struct ModuleInfo
 };
 
 ModuleInfo GetModuleInfo(std::string moduleName);
+
+void PrintModuleInfo(std::string name, const ModuleInfo& loadedModuleInfo, std::string_view configVersion);

--- a/DxDispatch/src/dxdispatch/ModuleInfo.h
+++ b/DxDispatch/src/dxdispatch/ModuleInfo.h
@@ -1,0 +1,9 @@
+#pragma once
+
+struct ModuleInfo
+{
+    std::wstring path;
+    std::wstring version;
+};
+
+ModuleInfo GetModuleInfo(std::string moduleName);

--- a/DxDispatch/src/dxdispatch/main.cpp
+++ b/DxDispatch/src/dxdispatch/main.cpp
@@ -19,7 +19,9 @@ void PrintModuleInfo(std::string name, const ModuleInfo& loadedModuleInfo, std::
     std::cout << name << ":\n";
     std::cout << "- Configure Version : " << configVersion << std::endl;
     std::wcout << L"- Loaded Path       : " << loadedModuleInfo.path << std::endl;
+#if defined(_WIN32) && !defined(_GAMING_XBOX)
     std::wcout << L"- Loaded Version    : " << loadedModuleInfo.version << std::endl;
+#endif
     std::cout << std::endl;
 }
 
@@ -52,10 +54,12 @@ int main(int argc, char** argv)
 
     if (args.ShowDependencies())
     {
+#ifndef _GAMING_XBOX
         // D3D12.dll lazily loads D3D12Core.dll. Calling any exported function forces D3D12Core.dll to load
         // so its version can be printed, and GetDebugInterface is inexpensive.
         ComPtr<ID3D12Debug> debug;
         d3dModule->GetDebugInterface(IID_PPV_ARGS(&debug));
+#endif
 
         PrintModuleInfo("DirectML", GetModuleInfo("directml"), c_directmlConfig);
         PrintModuleInfo("D3D12", GetModuleInfo("d3d12core"), c_d3d12Config);// TODO: need to get version of loaded d3d12core.dll, not the shim

--- a/DxDispatch/src/dxdispatch/main.cpp
+++ b/DxDispatch/src/dxdispatch/main.cpp
@@ -14,17 +14,6 @@
 
 using Microsoft::WRL::ComPtr;
 
-void PrintModuleInfo(std::string name, const ModuleInfo& loadedModuleInfo, std::string_view configVersion)
-{
-    std::cout << name << ":\n";
-    std::cout << "- Configure Version : " << configVersion << std::endl;
-    std::wcout << L"- Loaded Path       : " << loadedModuleInfo.path << std::endl;
-#if defined(_WIN32) && !defined(_GAMING_XBOX)
-    std::wcout << L"- Loaded Version    : " << loadedModuleInfo.version << std::endl;
-#endif
-    std::cout << std::endl;
-}
-
 int main(int argc, char** argv)
 {
     CommandLineArgs args;

--- a/DxDispatch/src/dxdispatch/main.cpp
+++ b/DxDispatch/src/dxdispatch/main.cpp
@@ -10,7 +10,6 @@
 #include "Executor.h"
 #include "CommandLineArgs.h"
 #include "ModuleInfo.h"
-#include "config.h"
 
 using Microsoft::WRL::ComPtr;
 
@@ -43,19 +42,14 @@ int main(int argc, char** argv)
 
     if (args.ShowDependencies())
     {
-#ifndef _GAMING_XBOX
+#if defined(_WIN32) && !defined(_GAMING_XBOX)
         // D3D12.dll lazily loads D3D12Core.dll. Calling any exported function forces D3D12Core.dll to load
         // so its version can be printed, and GetDebugInterface is inexpensive.
-        ComPtr<ID3D12Debug> debug;
+        Microsoft::WRL::ComPtr<ID3D12Debug> debug;
         d3dModule->GetDebugInterface(IID_PPV_ARGS(&debug));
 #endif
 
-        PrintModuleInfo("DirectML", GetModuleInfo("directml"), c_directmlConfig);
-        PrintModuleInfo("D3D12", GetModuleInfo("d3d12core"), c_d3d12Config);// TODO: need to get version of loaded d3d12core.dll, not the shim
-        PrintModuleInfo("DXCompiler", GetModuleInfo("dxcompiler"), c_dxcompilerConfig);
-        PrintModuleInfo("PIX", GetModuleInfo("winpixeventruntime"), c_pixConfig);
-        PrintModuleInfo("ONNX Runtime", GetModuleInfo("onnxruntime"), c_ortConfig);
-
+        PrintDependencies();
         return 0;
     }
 


### PR DESCRIPTION
This change adds a new command-line option, `--show_dependencies` (or `-S`), which will print run-time path/version info for the main DX/ORT dependencies (directml.dll, d3d12core.dll, etc.). This is useful when overlaying custom versions of dependencies that differ from what the tool was configured against.

- **Configured Version**: the version of the dependency that dxdispatch was configured/built against.
- **Loaded Path**: file path to the dependency loaded at run time
- **Loaded Version**: file version of the dependency loaded at run time

Example output:
```
PS S:\directml\DxDispatch\build\win-x64\Debug> .\dxdispatch.exe -S
DirectML:
- Configured Version : NuGet (Microsoft.AI.DirectML.1.9.1)
- Loaded Path        : S:\directml_github\DxDispatch\build\win-x64\Debug\directml.dll
- Loaded Version     : 1.9.1+220902-1323.1.dml-1.9.d6f03b3

D3D12:
- Configured Version : NuGet (Microsoft.Direct3D.D3D12.1.606.3)
- Loaded Path        : S:\directml_github\DxDispatch\build\win-x64\Debug\D3D12\D3D12Core.dll
- Loaded Version     : 1.606.3.0.220714-1035.1.1.606.1de1208fe2aaf846fbd8779f86b44d62593104e1

DXCompiler:
- Configured Version : Release (v1.7.2207)
- Loaded Path        : S:\directml_github\DxDispatch\build\win-x64\Debug\dxcompiler.dll
- Loaded Version     : 1.7.2207.3 (e9137cd1d)

PIX:
- Configured Version : NuGet (WinPixEventRuntime.1.0.220124001)
- Loaded Path        : S:\directml_github\DxDispatch\build\win-x64\Debug\WinPixEventRuntime.dll
- Loaded Version     : 1.0.220124001-release

ONNX Runtime:
- Configured Version : NuGet (Microsoft.ML.OnnxRuntime.DirectML.1.12.1)
- Loaded Path        : S:\directml_github\DxDispatch\build\win-x64\Debug\onnxruntime.dll
- Loaded Version     : 1.12.20220803.2.7048164
```