### PR TITLE
DxDispatch: support ONNX models with non-tensor outputs

### DIFF
--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -139,7 +139,6 @@ void OnnxDispatchable::Bind(const Bindings& bindings)
             // Input tensors must be always be bound. Outputs are optional.
             if (isInputTensor || bindings.find(tensorName) != bindings.end())
             {
-                // TODO: allocate tensor inputs on CPU if unsupported type for DML 
                 if (typeInfo.GetONNXType() != ONNXType::ONNX_TYPE_TENSOR)
                 {
                     continue;

--- a/DxDispatch/src/model/OnnxParsers.cpp
+++ b/DxDispatch/src/model/OnnxParsers.cpp
@@ -130,7 +130,7 @@ Model OnnxParsers::ParseModel(
             
             if (typeInfo.GetONNXType() != ONNXType::ONNX_TYPE_TENSOR)
             {
-                throw std::invalid_argument("Unsupported non-tensor input/output in ONNX model");
+                continue;
             }
 
             // DxDispatch's execution model assumes that all resources can be pre-allocated and


### PR DESCRIPTION
This change enables running ONNX models with non-tensor-type outputs. These outputs cannot be allocated by the DML EP, so non-tensor outputs (and tensor outputs with unsupported data types) are allocated with the CPU allocator.