### PR TITLE
DxDispatch: keep ref on Ort::Env and allow CPU EP to allocate inputs

### DIFF
--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -87,8 +87,8 @@ void OnnxDispatchable::Initialize()
     const OrtApi& ortApi = Ort::GetApi();
     Ort::ThrowOnError(ortApi.GetExecutionProviderApi("DML", ORT_API_VERSION, reinterpret_cast<const void**>(&m_ortDmlApi)));
 
-    Ort::Env ortEnvironment(ORT_LOGGING_LEVEL_WARNING, "DxDispatch"); // Note ORT_LOGGING_LEVEL_VERBOSE is useful too.
-    
+    m_environment = Ort::Env(ORT_LOGGING_LEVEL_WARNING, "DxDispatch"); // Note ORT_LOGGING_LEVEL_VERBOSE is useful too.
+
     Ort::SessionOptions sessionOptions;
     sessionOptions.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
     sessionOptions.DisableMemPattern();
@@ -108,12 +108,33 @@ void OnnxDispatchable::Initialize()
     Ort::ThrowOnError(ortApi.GetExecutionProviderApi("DML", ORT_API_VERSION, reinterpret_cast<const void**>(&ortDmlApi)));
     Ort::ThrowOnError(ortDmlApi->SessionOptionsAppendExecutionProvider_DML1(sessionOptions, m_device->DML(), m_device->GetCommandQueue()));
 
-    m_session = Ort::Session(ortEnvironment, m_desc.sourcePath.wstring().c_str(), sessionOptions);
+    m_session = Ort::Session(*m_environment, m_desc.sourcePath.wstring().c_str(), sessionOptions);
     m_ioBindings = Ort::IoBinding::IoBinding(*m_session);
 }
 
 void OnnxDispatchable::Bind(const Bindings& bindings)
 {
+    // This table summarizes the resource bindings provided to the ONNX Runtime session:
+    //
+    // Kind   | Type       | DXD Binding    | DML Supported Data Type | ORT binding
+    // -------|------------|----------------|-------------------------|----------------------------------
+    // input  | tensor     | true           | *                       | pre-allocated DX resource
+    // input  | tensor     | false          | true                    | explicit DX resource (uninitialized values)
+    // input  | tensor     | false          | false                   | explicit CPU resource (uninitialized values)
+    // input  | non-tensor | *              | *                       | none
+    // output | tensor     | true           | *                       | pre-allocated DX resource
+    // output | tensor     | false          | true                    | implicit DX resource
+    // output | tensor     | false          | false                   | implicit CPU resource
+    // output | non-tensor | *              | *                       | implicit CPU resource
+    //
+    // - "DXD Binding" refers to the binding specified in a DxDispatch JSON model or created by OnnxParsers::ParseModel. 
+    // - "ORT Binding" refers to the final binding passed to the ONNX Runtime session.
+    // - OnnxParsers::ParseModel is configured to create DXD bindings only for tensor-type inputs with a DML supported data type.
+    // - A pre-allocated DX resource is a buffer that is created by DxDispatch (independently of the ONNX model/session).
+    // - An explicit ORT binding means creating an Ort::Value and storing it in m_tensors.
+    // - An implicit ORT binding means passing an Ort::MemoryInfo to Ort::IoBinding::BindOutput, which lets the underlying
+    //   execution provider allocate as necessary. This is useful when outputs have dynamic shapes that can't be pre-allocated.
+
     m_ioBindings->ClearBoundInputs();
     m_ioBindings->ClearBoundOutputs();
     m_tensors.clear();
@@ -135,68 +156,104 @@ void OnnxDispatchable::Bind(const Bindings& bindings)
             Ort::TypeInfo typeInfo = isInputTensor ? m_session->GetInputTypeInfo(tensorIndex) : m_session->GetOutputTypeInfo(tensorIndex);
             std::string tensorName = OnnxParsers::GetTensorName(tensorIndex, *m_session, isInputTensor);
 
-            // Input tensors must be always be bound. Outputs are optional.
-            if (isInputTensor || bindings.find(tensorName) != bindings.end())
+            std::vector<int64_t> tensorShape;
+            bool isDmlSupportedType = false;
+            ONNXTensorElementDataType tensorDataType = ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+            if (typeInfo.GetONNXType() == ONNXType::ONNX_TYPE_TENSOR)
             {
-                if (typeInfo.GetONNXType() != ONNXType::ONNX_TYPE_TENSOR)
-                {
-                    continue;
-                }
-
                 Ort::Unowned<Ort::TensorTypeAndShapeInfo> shapeInfo = typeInfo.GetTensorTypeAndShapeInfo();
-                const ONNXTensorElementDataType tensorDataType = shapeInfo.GetElementType();
-                if (!OnnxParsers::IsSupportedOnnxTensorElementDataType(tensorDataType))
-                {
-                    throw std::runtime_error("Unsupported tensor data type");
-                }
 
-                // Convert free dimensions (-1) to their minimum positive size (1).
-                std::vector<int64_t> tensorShape = shapeInfo.GetShape();
+                tensorShape = shapeInfo.GetShape();
                 for (auto& dim : tensorShape)
                 {
                     dim = std::abs(dim);
                 }
 
-                auto resource = GetResourceFromModelBinding(tensorName, bindings);
+                tensorDataType = shapeInfo.GetElementType();
+                isDmlSupportedType = OnnxParsers::IsSupportedOnnxTensorElementDataType(tensorDataType);
 
-                // Create an ORT tensor from the existing D3D resource.
-                Microsoft::WRL::ComPtr<IUnknown> resourceWrapper;
-                m_tensors.emplace_back(CreateTensorFromResource(
-                    m_ortDmlApi,
-                    dmlMemoryInformation,
-                    resource,
-                    tensorShape,
-                    tensorDataType,
-                    &resourceWrapper));
-
-                m_tensorWrappers.push_back(std::move(resourceWrapper));
-
-                // Bind the tensor.
-                if (isInputTensor)
+                if (bindings.find(tensorName) == bindings.end())
                 {
-                    m_ioBindings->BindInput(tensorName.c_str(), m_tensors.back());
+                    // No DXD binding exists, so allocate input tensors on the CPU.
+                    // Outputs are implicitly allocated using memInfo to handle dynamic shapes.
+                    if (isInputTensor)
+                    {
+                        if (isDmlSupportedType)
+                        {
+                            // Allocate a DX resource.
+                            std::vector<uint32_t> sizes;
+                            for (auto& dimSize : tensorShape) { sizes.push_back(static_cast<uint32_t>(dimSize)); }
+                            auto resource = m_device->CreateDefaultBuffer(DMLCalcBufferTensorSize(
+                                OnnxParsers::ConvertOnnxTensorDataType(tensorDataType),
+                                sizes.size(),
+                                sizes.data(),
+                                nullptr
+                                ));
+
+                            // Wrap the explicitly allocated DX resource.
+                            Microsoft::WRL::ComPtr<IUnknown> resourceWrapper;
+                            m_tensors.emplace_back(CreateTensorFromResource(
+                                m_ortDmlApi,
+                                dmlMemoryInformation,
+                                resource.Get(),
+                                tensorShape,
+                                tensorDataType,
+                                &resourceWrapper));
+
+                            m_tensorWrappers.push_back(std::move(resourceWrapper));
+                        }
+                        else
+                        {
+                            auto allocator = static_cast<OrtAllocator*>(Ort::AllocatorWithDefaultOptions());
+                            m_tensors.emplace_back(Ort::Value::CreateTensor(
+                                allocator, 
+                                tensorShape.data(),
+                                tensorShape.size(), 
+                                tensorDataType));
+                        }
+                    }
                 }
                 else
                 {
-                    m_ioBindings->BindOutput(tensorName.c_str(), m_tensors.back());
+                    // Wrap the pre-allocated DX resource.
+                    Microsoft::WRL::ComPtr<IUnknown> resourceWrapper;
+                    m_tensors.emplace_back(CreateTensorFromResource(
+                        m_ortDmlApi,
+                        dmlMemoryInformation,
+                        GetResourceFromModelBinding(tensorName, bindings),
+                        tensorShape,
+                        tensorDataType,
+                        &resourceWrapper));
+
+                    m_tensorWrappers.push_back(std::move(resourceWrapper));
                 }
+            }
+
+            if (isInputTensor)
+            {
+                if (typeInfo.GetONNXType() != ONNXType::ONNX_TYPE_TENSOR)
+                {
+                    // Don't bind non-tensor inputs.
+                    continue;
+                }
+
+                // Bind the input tensor.
+                m_ioBindings->BindInput(tensorName.c_str(), m_tensors.back());
             }
             else
             {
                 assert(!isInputTensor);
 
-                bool isDmlSupportedType = false;
-
-                if (typeInfo.GetONNXType() == ONNXType::ONNX_TYPE_TENSOR)
+                if (bindings.find(tensorName) == bindings.end())
                 {
-                    Ort::Unowned<Ort::TensorTypeAndShapeInfo> shapeInfo = typeInfo.GetTensorTypeAndShapeInfo();
-                    const ONNXTensorElementDataType tensorDataType = shapeInfo.GetElementType();
-                    isDmlSupportedType = OnnxParsers::IsSupportedOnnxTensorElementDataType(tensorDataType);
-
+                    // Let the execution provider allocate the output.
+                    m_ioBindings->BindOutput(tensorName.c_str(), isDmlSupportedType ? dmlMemoryInformation : cpuMemoryInformation);
                 }
-
-                // Let the execution provider allocate the output.
-                m_ioBindings->BindOutput(tensorName.c_str(), isDmlSupportedType ? dmlMemoryInformation : cpuMemoryInformation);
+                else
+                {
+                    // Bind the pre-allocated DX resource.
+                    m_ioBindings->BindOutput(tensorName.c_str(), m_tensors.back());
+                }
             }
         }
     }

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.h
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.h
@@ -20,6 +20,7 @@ public:
 private:
     std::shared_ptr<Device> m_device;
     const Model::OnnxDispatchableDesc& m_desc;
+    std::optional<Ort::Env> m_environment;
     std::optional<Ort::Session> m_session;
     const OrtDmlApi* m_ortDmlApi = nullptr;
     const CommandLineArgs& m_args;

--- a/DxDispatch/src/model/OnnxParsers.cpp
+++ b/DxDispatch/src/model/OnnxParsers.cpp
@@ -17,14 +17,14 @@ bool OnnxParsers::IsSupportedOnnxTensorElementDataType(ONNXTensorElementDataType
     switch (dataType)
     {
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED:   return false;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:        return true;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:        return false;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:       return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:        return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING:      return false;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:      return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:       return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:     return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:    return true;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:    return false;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:       return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:      return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:       return true;
@@ -147,7 +147,8 @@ Model OnnxParsers::ParseModel(
                 const ONNXTensorElementDataType tensorDataType = shapeInfo.GetElementType();
                 if (!OnnxParsers::IsSupportedOnnxTensorElementDataType(tensorDataType))
                 {
-                    throw std::invalid_argument("Unsupported tensor data type in ONNX model");
+                    // Let the CPU execution provider allocate the input.
+                    continue;
                 }
 
                 uint64_t elementCount = 1;

--- a/DxDispatch/src/model/OnnxParsers.cpp
+++ b/DxDispatch/src/model/OnnxParsers.cpp
@@ -17,14 +17,14 @@ bool OnnxParsers::IsSupportedOnnxTensorElementDataType(ONNXTensorElementDataType
     switch (dataType)
     {
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED:   return false;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:        return false;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:        return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:       return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:        return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING:      return false;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:      return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:       return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:     return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:    return false;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:    return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:       return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:      return true;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:       return true;


### PR DESCRIPTION
Three changes here:
- Fixes a bug where Ort::Env was not kept alive in the OnnxDispatchable class. The Ort::Session does not keep a ref on this object.
- OnnxParsers now allows inputs with data types not supported by DML. The OnnxDispatchable will explicitly allocate these inputs on the CPU.
- For inputs with data types that _are_ suppported by DML, but not explicitly bound, OnnxDispatchable will explicitly allocate the input as a DX resource. This path will only be taken if a JSON model is provided and some inputs are left unbound; OnnxParsers will always create bindings for supported inputs.

Some comments were added to help clarify all the binding paths that can be taken. Hopefully this is the last change I need to make here to support the more efficient IO binding with pre-allocated tensors yet have fallback in cases where it doesn't work. Output tensors could be pre-allocated if there was a way to know if they have dynamic shapes or not; I need to do more research to see if this is possible.