### PR TITLE
DxDispatch: Upgrade ORT & PIX

### DIFF
--- a/DxDispatch/cmake/onnxruntime.cmake
+++ b/DxDispatch/cmake/onnxruntime.cmake
@@ -52,13 +52,13 @@ function(init_onnxruntime_cache_variables prefix)
 
     # <PREFIX>_ONNXRUNTIME_NUGET_VERSION
     set(${prefix}_ONNXRUNTIME_NUGET_VERSION
-        1.12.1
+        1.13.1
         CACHE STRING "Version of the ONNX Runtime NuGet package (TYPE == nuget)."
     )
 
     # <PREFIX>_ONNXRUNTIME_NUGET_HASH
     set(${prefix}_ONNXRUNTIME_NUGET_HASH 
-        6a8c53904c6169d910e39ebbceac953060e8c5b41a6303dff63ba99a09686bbd
+        c8c925fefb07be6565919c29744e0c011b3989a817f60d6ab65ea357d64b24f8
         CACHE STRING "SHA256 hash of the ONNX Runtime NuGet package (TYPE == nuget)."
     )
 

--- a/DxDispatch/cmake/pix.cmake
+++ b/DxDispatch/cmake/pix.cmake
@@ -53,13 +53,13 @@ function(init_pix_cache_variables prefix)
 
     # <PREFIX>_PIX_NUGET_VERSION
     set(${prefix}_PIX_NUGET_VERSION
-        1.0.220124001
+        1.0.220810001
         CACHE STRING "Version of the PIX event runtime NuGet package (TYPE == nuget)."
     )
 
     # <PREFIX>_PIX_NUGET_HASH
     set(${prefix}_PIX_NUGET_HASH 
-        5b194b1ee6596a00ae3caedf7b70204d3a6c737e91333d7f971baec46b9666d9
+        05cc57913ca6142df26834ef96ddeefcff00ce71a45d2df66b68d904ce8aa35d
         CACHE STRING "SHA256 hash of the PIX event runtime NuGet package (TYPE == nuget)."
     )
 endfunction()

--- a/DxDispatch/src/model/OnnxParsers.cpp
+++ b/DxDispatch/src/model/OnnxParsers.cpp
@@ -6,9 +6,8 @@
 std::string OnnxParsers::GetTensorName(size_t index, Ort::Session const& session, bool isInput)
 {
     Ort::AllocatorWithDefaultOptions allocator;
-    char* name = isInput ? session.GetInputName(index, allocator) : session.GetOutputName(index, allocator);
-    std::string returnName(name);
-    allocator.Free(name); // Don't leak memory.
+    auto name = isInput ? session.GetInputNameAllocated(index, allocator) : session.GetOutputNameAllocated(index, allocator);
+    std::string returnName(name.get());
     return returnName;
 }
 


### PR DESCRIPTION
Upgrades ORT to 1.13.1 and PIX event runtime to latest.

Only code change is replacing deprecated `OrtSession::GetInputName` with `OrtSession::GetInputNameAllocated`, which no longre requires the caller to free the returned string.