### PR TITLE
DxDispatch: pre-allocate ONNX outputs with static shapes

### DIFF
--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -92,7 +92,8 @@ void OnnxDispatchable::Initialize()
     Ort::SessionOptions sessionOptions;
     sessionOptions.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
     sessionOptions.DisableMemPattern();
-    sessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_EXTENDED); // Note ORT_ENABLE_BASIC is useful for debugging.
+    sessionOptions.DisableCpuMemArena();
+    sessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL); // Note ORT_ENABLE_BASIC is useful for debugging.
  
     for (auto& freeDimOverride : m_args.GetOnnxFreeDimensionNameOverrides())
     {

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -129,7 +129,6 @@ void OnnxDispatchable::Bind(const Bindings& bindings)
     //
     // - "DXD Binding" refers to the binding specified in a DxDispatch JSON model or created by OnnxParsers::ParseModel. 
     // - "ORT Binding" refers to the final binding passed to the ONNX Runtime session.
-    // - OnnxParsers::ParseModel is configured to create DXD bindings only for tensor-type inputs with a DML supported data type.
     // - A pre-allocated DX resource is a buffer that is created by DxDispatch (independently of the ONNX model/session).
     // - An explicit ORT binding means creating an Ort::Value and storing it in m_tensors.
     // - An implicit ORT binding means passing an Ort::MemoryInfo to Ort::IoBinding::BindOutput, which lets the underlying

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -92,7 +92,6 @@ void OnnxDispatchable::Initialize()
     Ort::SessionOptions sessionOptions;
     sessionOptions.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
     sessionOptions.DisableMemPattern();
-    sessionOptions.DisableCpuMemArena();
     sessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL); // Note ORT_ENABLE_BASIC is useful for debugging.
  
     for (auto& freeDimOverride : m_args.GetOnnxFreeDimensionNameOverrides())

--- a/DxDispatch/src/model/OnnxParsers.cpp
+++ b/DxDispatch/src/model/OnnxParsers.cpp
@@ -11,67 +11,71 @@ std::string OnnxParsers::GetTensorName(size_t index, Ort::Session const& session
     return returnName;
 }
 
-bool OnnxParsers::IsSupportedOnnxTensorElementDataType(ONNXTensorElementDataType dataType)
+OnnxParsers::DataTypeInfo OnnxParsers::GetDataTypeInfo(ONNXTensorElementDataType dataType)
 {
-    switch (dataType)
-    {
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED:   return false;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:        return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:       return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:        return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING:      return false;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:      return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:       return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:     return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:    return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:       return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:      return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:       return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:      return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:       return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:      return true;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:   return false;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128:  return false;
-    default: return false;
-    }
-}
+    DataTypeInfo info = {};
+    info.onnxDataType = dataType;
+    info.dmlDataType = DML_TENSOR_DATA_TYPE_UNKNOWN;
 
-DML_TENSOR_DATA_TYPE OnnxParsers::ConvertOnnxTensorDataType(ONNXTensorElementDataType dataType)
-{
     switch (dataType)
     {
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:   return DML_TENSOR_DATA_TYPE_UINT8;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:    return DML_TENSOR_DATA_TYPE_INT8;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:  return DML_TENSOR_DATA_TYPE_UINT16;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:   return DML_TENSOR_DATA_TYPE_INT16;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16: return DML_TENSOR_DATA_TYPE_FLOAT16;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:   return DML_TENSOR_DATA_TYPE_INT32;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:  return DML_TENSOR_DATA_TYPE_UINT32;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:   return DML_TENSOR_DATA_TYPE_FLOAT32;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:  return DML_TENSOR_DATA_TYPE_UINT64;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:   return DML_TENSOR_DATA_TYPE_INT64;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:  return DML_TENSOR_DATA_TYPE_FLOAT64;
-    default: throw std::invalid_argument("Unsupported tensor type");
-    }
-}
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+        info.dmlDataType = DML_TENSOR_DATA_TYPE_UINT8;
+        info.sizeInBytes = 1;
+        break;
 
-static uint32_t OnnxTensorDataTypeSize(ONNXTensorElementDataType dataType)
-{
-    switch (dataType)
-    {
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:   return 1;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:    return 1;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:  return 2;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:   return 2;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16: return 2;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:   return 4;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:  return 4;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:   return 4;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:  return 8;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:   return 8;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:  return 8;
-    default: throw std::invalid_argument("Unsupported tensor type");
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+        info.dmlDataType = DML_TENSOR_DATA_TYPE_INT8;
+        info.sizeInBytes = 1;
+        break;
+
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
+        info.dmlDataType = DML_TENSOR_DATA_TYPE_UINT16;
+        info.sizeInBytes = 2;
+        break;
+
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
+        info.dmlDataType = DML_TENSOR_DATA_TYPE_INT16;
+        info.sizeInBytes = 2;
+        break;
+
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+        info.dmlDataType = DML_TENSOR_DATA_TYPE_FLOAT16;
+        info.sizeInBytes = 2;
+        break;
+
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+        info.dmlDataType = DML_TENSOR_DATA_TYPE_INT32;
+        info.sizeInBytes = 4;
+        break;
+
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
+        info.dmlDataType = DML_TENSOR_DATA_TYPE_UINT32;
+        info.sizeInBytes = 4;
+        break;
+
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+        info.dmlDataType = DML_TENSOR_DATA_TYPE_FLOAT32;
+        info.sizeInBytes = 4;
+        break;
+
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
+        info.dmlDataType = DML_TENSOR_DATA_TYPE_UINT64;
+        info.sizeInBytes = 8;
+        break;
+
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+        info.dmlDataType = DML_TENSOR_DATA_TYPE_INT64;
+        info.sizeInBytes = 8;
+        break;
+
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+        info.dmlDataType = DML_TENSOR_DATA_TYPE_FLOAT64;
+        info.sizeInBytes = 8;
+        break;
     }
+
+    return info;
 }
 
 Model OnnxParsers::ParseModel(
@@ -133,7 +137,7 @@ Model OnnxParsers::ParseModel(
             }
 
             Ort::Unowned<Ort::TensorTypeAndShapeInfo> shapeInfo = typeInfo.GetTensorTypeAndShapeInfo();
-            const ONNXTensorElementDataType tensorDataType = shapeInfo.GetElementType();
+            auto dataTypeInfo = GetDataTypeInfo(shapeInfo.GetElementType());
 
             bool hasFreeDimensions = false;
             uint64_t elementCount = 1;
@@ -155,10 +159,10 @@ Model OnnxParsers::ParseModel(
             // remaining free dimensions and DML supports the tensor data type; otherwise, allocation will occur in the
             // OnnxDispatchable itself (either at binding or execution time). Unsupported tensor data types will be placed
             // on the CPU.
-            if (!hasFreeDimensions && IsSupportedOnnxTensorElementDataType(tensorDataType))
+            if (!hasFreeDimensions && dataTypeInfo.dmlDataType != DML_TENSOR_DATA_TYPE_UNKNOWN)
             {
                 Model::BufferDesc bufferDesc = {};
-                bufferDesc.initialValuesDataType = ConvertOnnxTensorDataType(tensorDataType);
+                bufferDesc.initialValuesDataType = dataTypeInfo.dmlDataType;
                 bufferDesc.sizeInBytes = DMLCalcBufferTensorSize(
                     bufferDesc.initialValuesDataType,
                     sizes.size(),
@@ -170,7 +174,7 @@ Model OnnxParsers::ParseModel(
                 bindings[resourceDesc.name] = {Model::BufferBindingSource{
                     resourceDesc.name,
                     elementCount,
-                    OnnxTensorDataTypeSize(tensorDataType)
+                    dataTypeInfo.sizeInBytes
                 }};
 
                 resources.emplace_back(std::move(resourceDesc));

--- a/DxDispatch/src/model/OnnxParsers.cpp
+++ b/DxDispatch/src/model/OnnxParsers.cpp
@@ -154,6 +154,12 @@ Model OnnxParsers::ParseModel(
                 elementCount *= sizes.back();
             }
 
+            // Scalars have empty shapes.
+            if (sizes.empty())
+            {
+                sizes.push_back(1);
+            }
+
             // It's best to pre-allocate DX resources for efficiency: the resource can be allocated once and bound without 
             // incurring any copies or repeated allocations. It's safe to pre-allocate a resource so long as there are no 
             // remaining free dimensions and DML supports the tensor data type; otherwise, allocation will occur in the

--- a/DxDispatch/src/model/OnnxParsers.h
+++ b/DxDispatch/src/model/OnnxParsers.h
@@ -7,9 +7,14 @@ namespace OnnxParsers
 {
     std::string GetTensorName(size_t index, Ort::Session const& session, bool isInput);
 
-    bool IsSupportedOnnxTensorElementDataType(ONNXTensorElementDataType dataType);
+    struct DataTypeInfo
+    {
+        ONNXTensorElementDataType onnxDataType;
+        DML_TENSOR_DATA_TYPE dmlDataType;
+        uint32_t sizeInBytes;
+    };
 
-    DML_TENSOR_DATA_TYPE ConvertOnnxTensorDataType(ONNXTensorElementDataType dataType);
+    DataTypeInfo GetDataTypeInfo(ONNXTensorElementDataType dataType);
 
     // Generates a DxDispatch model that has appropriate resources for an ONNX model's
     // inputs and outputs. The resources will be initialized with random values.


### PR DESCRIPTION
Final change (I hope) for ONNX-related binding. This will pre-allocate DX resources for outputs so long as their shapes are statically known. Dynamic shapes will be allocated by the EP (slightly less efficient). Minor code cleanup.