### PR TITLE
Make model files relative

### DIFF
--- a/DxDispatch/models/hlsl_add_fp16.json
+++ b/DxDispatch/models/hlsl_add_fp16.json
@@ -34,7 +34,7 @@
         "add": 
         {
             "type": "hlsl",
-            "sourcePath": "./hlsl_add.hlsl",
+            "sourcePath": "hlsl_add.hlsl",
             "compiler": "dxc",
             "compilerArgs": 
             [

--- a/DxDispatch/models/hlsl_add_fp16.json
+++ b/DxDispatch/models/hlsl_add_fp16.json
@@ -34,7 +34,7 @@
         "add": 
         {
             "type": "hlsl",
-            "sourcePath": "models/hlsl_add.hlsl",
+            "sourcePath": "./hlsl_add.hlsl",
             "compiler": "dxc",
             "compilerArgs": 
             [

--- a/DxDispatch/models/hlsl_add_fp32.json
+++ b/DxDispatch/models/hlsl_add_fp32.json
@@ -34,7 +34,7 @@
         "add": 
         {
             "type": "hlsl",
-            "sourcePath": "./hlsl_add.hlsl",
+            "sourcePath": "hlsl_add.hlsl",
             "compiler": "dxc",
             "compilerArgs": 
             [

--- a/DxDispatch/models/hlsl_add_fp32.json
+++ b/DxDispatch/models/hlsl_add_fp32.json
@@ -34,7 +34,7 @@
         "add": 
         {
             "type": "hlsl",
-            "sourcePath": "models/hlsl_add.hlsl",
+            "sourcePath": "./hlsl_add.hlsl",
             "compiler": "dxc",
             "compilerArgs": 
             [

--- a/DxDispatch/models/onnx_gemm.json
+++ b/DxDispatch/models/onnx_gemm.json
@@ -35,7 +35,7 @@
         "gemm": 
         {
             "type": "onnx",
-            "sourcePath": "./onnx_gemm.onnx"
+            "sourcePath": "onnx_gemm.onnx"
         }
     },
 

--- a/DxDispatch/models/onnx_gemm.json
+++ b/DxDispatch/models/onnx_gemm.json
@@ -35,7 +35,7 @@
         "gemm": 
         {
             "type": "onnx",
-            "sourcePath": "models/onnx_gemm.onnx"
+            "sourcePath": "./onnx_gemm.onnx"
         }
     },
 


### PR DESCRIPTION
Running DxDispatch from another directory (like the build\win-x64\Debug folder) yields errors. This just makes it more intuitive.

```
Failed to execute the model: ERROR while initializing 'add':
S:\DirectML@github\DxDispatch\src\dxdispatch\HlslDispatchable.cpp(194)\dxdispatch.exe!00007FF6CB381025: (caller: 00007FF6CB3577E9) Exception(1) tid(4778)
80070003 The system cannot find the path specified.
```