### PR TITLE
Comparison type fix in dxdispatch helper script

### DIFF
--- a/DxDispatch/tools/AnalyzePixGpuCapture.ps1
+++ b/DxDispatch/tools/AnalyzePixGpuCapture.ps1
@@ -76,7 +76,7 @@ foreach ($Event in $Events)
         # Get the top-level DML operator name
         $DmlOpName = "Other"
         $CurrentEvent = $Event
-        while ($CurrentEvent.Parent -ge 0)
+        while ([int]$CurrentEvent.Parent -ge 0)
         {
             $CurrentEvent = $Events[$CurrentEvent.Parent]
             if ($CurrentEvent.Name.StartsWith('DML_OPERATOR'))


### PR DESCRIPTION
`$CurrenntEvent.Parent` is treated as a string, so this line is doing a string comparison instead of a numeric comparison.