### PR TITLE
add training/hyperparam yaml files- not the actual data

### DIFF
--- a/PyTorch/1.13/yolov3/.gitignore
+++ b/PyTorch/1.13/yolov3/.gitignore
@@ -25,16 +25,7 @@
 
 storage.googleapis.com
 runs/*
-data/*
-!data/images/zidane.jpg
-!data/images/bus.jpg
-!data/coco.names
-!data/coco_paper.names
-!data/coco.data
-!data/coco_*.data
-!data/coco_*.txt
-!data/trainvalno5k.shapes
-!data/*.sh
+
 
 pycocotools/*
 results*.txt

--- a/PyTorch/1.13/yolov3/.gitignore
+++ b/PyTorch/1.13/yolov3/.gitignore
@@ -25,7 +25,17 @@
 
 storage.googleapis.com
 runs/*
-
+data/*
+!data/images/zidane.jpg
+!data/images/bus.jpg
+!data/coco.names
+!data/coco_paper.names
+!data/coco.data
+!data/coco_*.data
+!data/coco_*.txt
+!data/trainvalno5k.shapes
+!data/*.sh
+!data/*.yaml
 
 pycocotools/*
 results*.txt

--- a/PyTorch/1.13/yolov3/data/coco128.yaml
+++ b/PyTorch/1.13/yolov3/data/coco128.yaml
@@ -1,0 +1,28 @@
+# COCO 2017 dataset http://cocodataset.org - first 128 training images
+# Train command: python train.py --data coco128.yaml
+# Default dataset location is next to YOLOv3:
+#   /parent_folder
+#     /coco128
+#     /yolov3
+
+
+# download command/URL (optional)
+download: https://github.com/ultralytics/yolov5/releases/download/v1.0/coco128.zip
+
+# train and val data as 1) directory: path/images/, 2) file: path/images.txt, or 3) list: [path1/images/, path2/images/]
+train: ../coco128/images/train2017/  # 128 images
+val: ../coco128/images/train2017/  # 128 images
+
+# number of classes
+nc: 80
+
+# class names
+names: [ 'person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train', 'truck', 'boat', 'traffic light',
+         'fire hydrant', 'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog', 'horse', 'sheep', 'cow',
+         'elephant', 'bear', 'zebra', 'giraffe', 'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
+         'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat', 'baseball glove', 'skateboard', 'surfboard',
+         'tennis racket', 'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl', 'banana', 'apple',
+         'sandwich', 'orange', 'broccoli', 'carrot', 'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
+         'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop', 'mouse', 'remote', 'keyboard', 'cell phone',
+         'microwave', 'oven', 'toaster', 'sink', 'refrigerator', 'book', 'clock', 'vase', 'scissors', 'teddy bear',
+         'hair drier', 'toothbrush' ]

--- a/PyTorch/1.13/yolov3/data/hyp.scratch.yaml
+++ b/PyTorch/1.13/yolov3/data/hyp.scratch.yaml
@@ -1,0 +1,33 @@
+# Hyperparameters for COCO training from scratch
+# python train.py --batch 40 --cfg yolov5m.yaml --weights '' --data coco.yaml --img 640 --epochs 300
+# See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials
+
+
+lr0: 0.01  # initial learning rate (SGD=1E-2, Adam=1E-3)
+lrf: 0.2  # final OneCycleLR learning rate (lr0 * lrf)
+momentum: 0.937  # SGD momentum/Adam beta1
+weight_decay: 0.0005  # optimizer weight decay 5e-4
+warmup_epochs: 3.0  # warmup epochs (fractions ok)
+warmup_momentum: 0.8  # warmup initial momentum
+warmup_bias_lr: 0.1  # warmup initial bias lr
+box: 0.05  # box loss gain
+cls: 0.5  # cls loss gain
+cls_pw: 1.0  # cls BCELoss positive_weight
+obj: 1.0  # obj loss gain (scale with pixels)
+obj_pw: 1.0  # obj BCELoss positive_weight
+iou_t: 0.20  # IoU training threshold
+anchor_t: 4.0  # anchor-multiple threshold
+# anchors: 3  # anchors per output layer (0 to ignore)
+fl_gamma: 0.0  # focal loss gamma (efficientDet default gamma=1.5)
+hsv_h: 0.015  # image HSV-Hue augmentation (fraction)
+hsv_s: 0.7  # image HSV-Saturation augmentation (fraction)
+hsv_v: 0.4  # image HSV-Value augmentation (fraction)
+degrees: 0.0  # image rotation (+/- deg)
+translate: 0.1  # image translation (+/- fraction)
+scale: 0.5  # image scale (+/- gain)
+shear: 0.0  # image shear (+/- deg)
+perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
+flipud: 0.0  # image flip up-down (probability)
+fliplr: 0.5  # image flip left-right (probability)
+mosaic: 1.0  # image mosaic (probability)
+mixup: 0.0  # image mixup (probability)

--- a/PyTorch/1.8/yolov3/.gitignore
+++ b/PyTorch/1.8/yolov3/.gitignore
@@ -25,10 +25,6 @@
 
 storage.googleapis.com
 runs/*
-
-pycocotools/*
-results*.txt
-gcp_test*.sh
 data/*
 !data/images/zidane.jpg
 !data/images/bus.jpg
@@ -40,6 +36,10 @@ data/*
 !data/trainvalno5k.shapes
 !data/*.sh
 !data/*.yaml
+
+pycocotools/*
+results*.txt
+gcp_test*.sh
 
 # Datasets -------------------------------------------------------------------------------------------------------------
 coco/

--- a/PyTorch/1.8/yolov3/.gitignore
+++ b/PyTorch/1.8/yolov3/.gitignore
@@ -25,16 +25,6 @@
 
 storage.googleapis.com
 runs/*
-data/*
-!data/images/zidane.jpg
-!data/images/bus.jpg
-!data/coco.names
-!data/coco_paper.names
-!data/coco.data
-!data/coco_*.data
-!data/coco_*.txt
-!data/trainvalno5k.shapes
-!data/*.sh
 
 pycocotools/*
 results*.txt

--- a/PyTorch/1.8/yolov3/.gitignore
+++ b/PyTorch/1.8/yolov3/.gitignore
@@ -29,6 +29,17 @@ runs/*
 pycocotools/*
 results*.txt
 gcp_test*.sh
+data/*
+!data/images/zidane.jpg
+!data/images/bus.jpg
+!data/coco.names
+!data/coco_paper.names
+!data/coco.data
+!data/coco_*.data
+!data/coco_*.txt
+!data/trainvalno5k.shapes
+!data/*.sh
+!data/*.yaml
 
 # Datasets -------------------------------------------------------------------------------------------------------------
 coco/

--- a/PyTorch/1.8/yolov3/data/coco128.yaml
+++ b/PyTorch/1.8/yolov3/data/coco128.yaml
@@ -1,0 +1,28 @@
+# COCO 2017 dataset http://cocodataset.org - first 128 training images
+# Train command: python train.py --data coco128.yaml
+# Default dataset location is next to YOLOv3:
+#   /parent_folder
+#     /coco128
+#     /yolov3
+
+
+# download command/URL (optional)
+download: https://github.com/ultralytics/yolov5/releases/download/v1.0/coco128.zip
+
+# train and val data as 1) directory: path/images/, 2) file: path/images.txt, or 3) list: [path1/images/, path2/images/]
+train: ../coco128/images/train2017/  # 128 images
+val: ../coco128/images/train2017/  # 128 images
+
+# number of classes
+nc: 80
+
+# class names
+names: [ 'person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train', 'truck', 'boat', 'traffic light',
+         'fire hydrant', 'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog', 'horse', 'sheep', 'cow',
+         'elephant', 'bear', 'zebra', 'giraffe', 'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
+         'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat', 'baseball glove', 'skateboard', 'surfboard',
+         'tennis racket', 'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl', 'banana', 'apple',
+         'sandwich', 'orange', 'broccoli', 'carrot', 'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
+         'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop', 'mouse', 'remote', 'keyboard', 'cell phone',
+         'microwave', 'oven', 'toaster', 'sink', 'refrigerator', 'book', 'clock', 'vase', 'scissors', 'teddy bear',
+         'hair drier', 'toothbrush' ]

--- a/PyTorch/1.8/yolov3/data/hyp.scratch.yaml
+++ b/PyTorch/1.8/yolov3/data/hyp.scratch.yaml
@@ -1,0 +1,33 @@
+# Hyperparameters for COCO training from scratch
+# python train.py --batch 40 --cfg yolov5m.yaml --weights '' --data coco.yaml --img 640 --epochs 300
+# See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials
+
+
+lr0: 0.01  # initial learning rate (SGD=1E-2, Adam=1E-3)
+lrf: 0.2  # final OneCycleLR learning rate (lr0 * lrf)
+momentum: 0.937  # SGD momentum/Adam beta1
+weight_decay: 0.0005  # optimizer weight decay 5e-4
+warmup_epochs: 3.0  # warmup epochs (fractions ok)
+warmup_momentum: 0.8  # warmup initial momentum
+warmup_bias_lr: 0.1  # warmup initial bias lr
+box: 0.05  # box loss gain
+cls: 0.5  # cls loss gain
+cls_pw: 1.0  # cls BCELoss positive_weight
+obj: 1.0  # obj loss gain (scale with pixels)
+obj_pw: 1.0  # obj BCELoss positive_weight
+iou_t: 0.20  # IoU training threshold
+anchor_t: 4.0  # anchor-multiple threshold
+# anchors: 3  # anchors per output layer (0 to ignore)
+fl_gamma: 0.0  # focal loss gamma (efficientDet default gamma=1.5)
+hsv_h: 0.015  # image HSV-Hue augmentation (fraction)
+hsv_s: 0.7  # image HSV-Saturation augmentation (fraction)
+hsv_v: 0.4  # image HSV-Value augmentation (fraction)
+degrees: 0.0  # image rotation (+/- deg)
+translate: 0.1  # image translation (+/- fraction)
+scale: 0.5  # image scale (+/- gain)
+shear: 0.0  # image shear (+/- deg)
+perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
+flipud: 0.0  # image flip up-down (probability)
+fliplr: 0.5  # image flip left-right (probability)
+mosaic: 1.0  # image mosaic (probability)
+mixup: 0.0  # image mixup (probability)


### PR DESCRIPTION
Add coco.yaml and hyperparam.yaml to allow yolov3 scripts to run. Note that this doesn't actually add any dataset, just points the scripts to the correct download location. 

Repro steps: Do a clean clone of DirectML repo and run train.py. Since the data folder doesn't exist (including the yaml metadata files), training can't run. 
![image](https://user-images.githubusercontent.com/5448665/213037266-8ea76ca8-6771-49ed-8e77-cfdf4800bed7.png)
