### PR TITLE
Support for node names in DMLX graphs

### DIFF
--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -38,6 +38,14 @@
     #define DMLX_OPTIONAL_EXTENDED
 #endif
 
+#if __cpp_exceptions
+    #include <stdexcept>
+#endif
+
+#if __cplusplus >= 201703L && __has_include(<string_view>)
+    #include <string_view>
+#endif
+
 /** Calculates the minimum number of bytes required to store a buffer tensor with the specified type, sizes, and
     strides. The formula can be expressed as the following:
 
@@ -241,7 +249,6 @@ namespace dml
 #endif
 
 #if __cplusplus >= 201703L && __has_include(<string_view>)
-    #include <string_view>
     using StringView = std::string_view;
 #else
     using StringView = const std::string&;
@@ -4207,7 +4214,7 @@ namespace dml
             {
                 uint32_t nodeIndex = static_cast<uint32_t>(desc.nodes.size());
 
-                desc.nodes.push_back(DML_OPERATOR_GRAPH_NODE_DESC{ node.op.Get(), (!node.name.empty() ? node.name->c_str() : nullptr) });
+                desc.nodes.push_back(DML_OPERATOR_GRAPH_NODE_DESC{ node.op.Get(), (!node.name.empty() ? node.name.c_str() : nullptr) });
 
                 // Walk through each of this node's inputs and add it as an edge
                 const uint32_t inputCount = static_cast<uint32_t>(node.inputs.size());

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -708,6 +708,9 @@ namespace dml
 
         NameScope CreateNameScope(StringView name) { return NameScope(m_graphBuilder.get(), name); }
 
+        void PushName(StringView name) { m_graphBuilder->PushName(name); }
+        void PopName() { m_graphBuilder->PopName(name); }
+
         Microsoft::WRL::ComPtr<IDMLCompiledOperator> Compile(
             DML_EXECUTION_FLAGS flags,
             Span<const Expression> outputs,

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -4176,7 +4176,7 @@ namespace dml
             node.inputs.assign(inputs.begin(), inputs.end());
             if (!m_name.empty())
             {
-                node.name = m_name.c_str();
+                node.name = m_name;
             }
 
             uint32_t index = static_cast<uint32_t>(m_operatorNodes.size());

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -709,7 +709,7 @@ namespace dml
         NameScope CreateNameScope(StringView name) { return NameScope(m_graphBuilder.get(), name); }
 
         void PushName(StringView name) { m_graphBuilder->PushName(name); }
-        void PopName() { m_graphBuilder->PopName(name); }
+        void PopName() { m_graphBuilder->PopName(); }
 
         Microsoft::WRL::ComPtr<IDMLCompiledOperator> Compile(
             DML_EXECUTION_FLAGS flags,


### PR DESCRIPTION
Adds some helpers to DirectMLX.h for setting graph node names. This will be useful in future versions of DML that incorporate node names into PIX events. This feature is intended to be helpful in correlating network architecture blocks with individual operators, so naming is done on the graph builder with a push-pop model (names separated by underscores).

Example:
```cpp
    dml::Graph g(dmlDevice.Get());

    auto a = dml::InputTensor(g, 0, dml::TensorDesc{ DML_TENSOR_DATA_TYPE_FLOAT32, dml::TensorDimensions{5} });
    auto b = dml::InputTensor(g, 0, dml::TensorDesc{ DML_TENSOR_DATA_TYPE_FLOAT32, dml::TensorDimensions{5} });

    g.PushName("arithmetic");
    auto c = a + b * b * 5;
    g.PopName();
```

You can also use a name scope object to automatically pop the name within a scope. Example:
```cpp
    dml::Expression c;
    {
        auto name = g.CreateNameScope("arithmetic");
        c = a + b * b * 5;
    }
```
