### PR TITLE
Update DxDispatch dependencies and event duration method

### DIFF
--- a/DxDispatch/CMakeLists.txt
+++ b/DxDispatch/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
-project(dxdispatch VERSION 0.11.0 LANGUAGES CXX)
+project(dxdispatch VERSION 0.12.0 LANGUAGES CXX)
 
 # ==============================================================================
 # External Libraries/Helpers

--- a/DxDispatch/README.md
+++ b/DxDispatch/README.md
@@ -90,11 +90,11 @@ DxDispatch tries to depend on pre-built redistributable versions of its external
 </table>
 
 The default redistributable versions of components (e.g. nuget, archives):
-- **DirectML (nuget)**: [Microsoft.AI.DirectML (1.9.0)](https://www.nuget.org/packages/Microsoft.AI.DirectML/1.9.0)
-- **Direct3D 12 (nuget)**: [Microsoft.Direct3D.D3D12 (1.606.3)](https://www.nuget.org/packages/Microsoft.Direct3D.D3D12/1.606.3)
-- **DX Compiler (archive)**: [July 2022 (v1.7.2207)](https://github.com/microsoft/DirectXShaderCompiler/releases/tag/v1.7.2207)
-- **PIX Event Runtime (nuget)**: [WinPixEventRuntime (1.0.220124001)](https://www.nuget.org/packages/WinPixEventRuntime/1.0.220124001)
-- **ONNX Runtime (nuget)**: [Microsoft.ML.OnnxRuntime.DirectML (1.12.1)](https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML/1.12.1)
+- **DirectML (nuget)**: [Microsoft.AI.DirectML (1.10.1)](https://www.nuget.org/packages/Microsoft.AI.DirectML/1.10.1) - 2023/01/26
+- **Direct3D 12 (nuget)**: [Microsoft.Direct3D.D3D12 (1.608.2)](https://www.nuget.org/packages/Microsoft.Direct3D.D3D12/1.608.2) -  2023/01/03
+- **DX Compiler (archive)**: [December 2022 (v1.7.2212)](https://github.com/microsoft/DirectXShaderCompiler/releases/tag/v1.7.2212) - 2022/12/16
+- **PIX Event Runtime (nuget)**: [WinPixEventRuntime (1.0.220810001)](https://www.nuget.org/packages/WinPixEventRuntime/1.0.220810001) - 2022/08/10
+- **ONNX Runtime (nuget)**: [Microsoft.ML.OnnxRuntime.DirectML (1.14.0)](https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML/1.14.0-dev-20230209-0844-6ccaeddefa) - 2023/02/10
 
 Configuration is done using CMake cache variables. For example, Direct3D can be switched to a system dependency by adding `-DDXD_DIRECT3D_TYPE=winsdk` to the command line when first configuring the project. Use `cmake-gui` or `ccmake` to view the available variables.
 

--- a/DxDispatch/cgmanifest.json
+++ b/DxDispatch/cgmanifest.json
@@ -15,7 +15,7 @@
         "type": "nuget",
         "nuget": {
           "name": "Microsoft.Direct3D.D3D12",
-          "version": "1.606.3"
+          "version": "1.608.2"
         }
       }
     },
@@ -24,7 +24,7 @@
         "type": "nuget",
         "nuget": {
           "name": "Microsoft.AI.DirectML",
-          "version": "1.9.1"
+          "version": "1.10.1"
         }
       }
     },
@@ -33,8 +33,8 @@
         "type": "other",
         "other": {
           "name": "DirectX Shader Compiler",
-          "version": "2022_07_18",
-          "downloadUrl": "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2207/dxc_2022_07_18.zip"
+          "version": "2022_12_16",
+          "downloadUrl": "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2212/dxc_2022_12_16.zip"
         }
       }
     },
@@ -116,7 +116,7 @@
         "type": "nuget",
         "nuget": {
           "name": "Microsoft.ML.OnnxRuntime.DirectML",
-          "version": "1.12.1"
+          "version": "1.14.0-dev-20230209-0844-6ccaeddefa"
         }
       }
     }

--- a/DxDispatch/cmake/d3d12.cmake
+++ b/DxDispatch/cmake/d3d12.cmake
@@ -57,13 +57,13 @@ function(init_d3d12_cache_variables prefix)
 
     # <PREFIX>_D3D12_NUGET_VERSION
     set(${prefix}_D3D12_NUGET_VERSION
-        1.606.3
+        1.608.2
         CACHE STRING "Version of the D3D12 NuGet package (TYPE == nuget)."
     )
 
     # <PREFIX>_D3D12_NUGET_HASH
     set(${prefix}_D3D12_NUGET_HASH 
-        cc0a216cfde4e650fe1fe07d2edc558c0cce7bcf89f2172deb9429cc5652eb09
+        aef1069b4a7434e07e62994b059ccbc86df08d1cd9acd63c11e079ae078fe21a
         CACHE STRING "SHA256 hash of the D3D12 NuGet package (TYPE == nuget)."
     )
 

--- a/DxDispatch/cmake/dxcompiler.cmake
+++ b/DxDispatch/cmake/dxcompiler.cmake
@@ -49,19 +49,19 @@ function(init_dxcompiler_cache_variables prefix)
 
     # <PREFIX>_DXCOMPILER_ARCHIVE_URL
     set(${prefix}_DXCOMPILER_ARCHIVE_URL 
-        https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2207/dxc_2022_07_18.zip
+        https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2212/dxc_2022_12_16.zip
         CACHE STRING "URL of the GitHub release archive (TYPE == archive)."
     )
 
     # <PREFIX>_DXCOMPILER_ARCHIVE_HASH
     set(${prefix}_DXCOMPILER_ARCHIVE_HASH 
-        6f421070f85c407f8c7daa456ca40460c52632fceabc7e4a02aef36d3c4b8837 
+        ed77c7775fcf1e117bec8b5bb4de6735af101b733d3920dda083496dceef130f 
         CACHE STRING "SHA256 hash of the GitHub release archive (TYPE == archive)."
     )
     
     # <PREFIX>_DXCOMPILER_SOURCE_TAG
     set(${prefix}_DXCOMPILER_SOURCE_TAG 
-        v1.7.2207
+        v1.7.2212
         CACHE STRING "Git commit/tag hash of the GitHub repo (TYPE == source)."
     )
 endfunction()

--- a/DxDispatch/cmake/onnxruntime.cmake
+++ b/DxDispatch/cmake/onnxruntime.cmake
@@ -52,13 +52,13 @@ function(init_onnxruntime_cache_variables prefix)
 
     # <PREFIX>_ONNXRUNTIME_NUGET_VERSION
     set(${prefix}_ONNXRUNTIME_NUGET_VERSION
-        1.13.1
+        1.14.0-dev-20230209-0844-6ccaeddefa
         CACHE STRING "Version of the ONNX Runtime NuGet package (TYPE == nuget)."
     )
 
     # <PREFIX>_ONNXRUNTIME_NUGET_HASH
     set(${prefix}_ONNXRUNTIME_NUGET_HASH 
-        c8c925fefb07be6565919c29744e0c011b3989a817f60d6ab65ea357d64b24f8
+        4055caf0e85bc2d6e8c0ff1194927fdd8c05d22a9560c18789e3a0368a40972d
         CACHE STRING "SHA256 hash of the ONNX Runtime NuGet package (TYPE == nuget)."
     )
 

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -160,7 +160,7 @@ void OnnxDispatchable::Bind(const Bindings& bindings)
 
             if (typeInfo.GetONNXType() == ONNXType::ONNX_TYPE_TENSOR)
             {
-                Ort::Unowned<Ort::TensorTypeAndShapeInfo> shapeInfo = typeInfo.GetTensorTypeAndShapeInfo();
+                auto shapeInfo = typeInfo.GetTensorTypeAndShapeInfo();
 
                 tensorShape = shapeInfo.GetShape();
                 for (auto& dim : tensorShape)

--- a/DxDispatch/src/model/OnnxParsers.cpp
+++ b/DxDispatch/src/model/OnnxParsers.cpp
@@ -136,7 +136,7 @@ Model OnnxParsers::ParseModel(
                 continue;
             }
 
-            Ort::Unowned<Ort::TensorTypeAndShapeInfo> shapeInfo = typeInfo.GetTensorTypeAndShapeInfo();
+            auto shapeInfo = typeInfo.GetTensorTypeAndShapeInfo();
             auto dataTypeInfo = GetDataTypeInfo(shapeInfo.GetElementType());
 
             bool hasFreeDimensions = false;

--- a/DxDispatch/tools/AnalyzePixGpuCapture.ps1
+++ b/DxDispatch/tools/AnalyzePixGpuCapture.ps1
@@ -131,7 +131,15 @@ if ($DmlOpDurationsNs.Count -gt 0)
         $TotalOpTimeNs += $DmlOpDurationsNs[$DmlOpName]
     }
 
-    Write-Host "Operator GPU Time (sum may exceed model time due to parallelism):"
+    if ($DurationType -eq 'TOP to EOP')
+    {
+        Write-Host "Operator GPU Time (sum may exceed model time due to parallelism):"
+    }
+    else
+    {
+        Write-Host "Operator GPU Time:"
+    }
+
     foreach ($DmlOpName in $DmlOpsSortedByDuration)
     {
         $DurationNs = $DmlOpDurationsNs[$DmlOpName]

--- a/DxDispatch/tools/AnalyzePixGpuCapture.ps1
+++ b/DxDispatch/tools/AnalyzePixGpuCapture.ps1
@@ -24,7 +24,7 @@ function PrettyDurationFormat($DurationNs)
     }
     if ($DurationNs -ge 1000)
     {
-        return "{0:f2} μs" -f ($DurationNs / 1000.0)
+        return "{0:f2} us" -f ($DurationNs / 1000.0)
     }
     return "{0:f2} ns" -f $DurationNs
 }
@@ -54,9 +54,9 @@ if ($InputFile.Extension -eq '.wpix')
     $PixCaptureFile = (Resolve-Path $InputPath).Path
     
     $CounterCommandLine = 
-        '--counters="Execution Start Time*"',
-        '--counters="$DurationType Duration*"',
-        '--counters="CS Invocations"'
+        "--counters=`"Execution Start Time*`"",
+        "--counters=`"$DurationType Duration*`"",
+        "--counters=`"CS Invocations`""
     
     $PixCaptureEventsFileName = "events.csv"
     & $PixtoolPath open-capture $PixCaptureFile save-event-list $CounterCommandLine $PixCaptureEventsFileName


### PR DESCRIPTION
- Updates binary dependencies (dxc, d3d, ort)
- Changes the default event duration measurement in AnalyzePixGpuCapture.ps1 from TOP-to-EOP to EOP-to-EOP.
- Fix ORT C++ API breaking changes in 1.14 (`Ort::Unowned<Ort::TensorTypeAndShapeInfo>` return type replaced with something else)