### PR TITLE
Increase CG task timeout

### DIFF
--- a/component-governance.yml
+++ b/component-governance.yml
@@ -11,5 +11,8 @@ trigger:
     include: 
     - master 
 
+variables:
+  ComponentDetection.Timeout: 1200
+
 steps:
   - task: ComponentGovernanceComponentDetection@0


### PR DESCRIPTION
Increase component governance task timeout from 6 min (default) to 20 min to avoid blocking PRs.