### PR TITLE
Update to newer version of pybind11 to fix compile error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "Python/pybind11"]
 	path = Python/pybind11
 	url = https://github.com/pybind/pybind11.git
-	branch = v2.5
+	branch = v2.10
 
 [submodule "Python/gpgmm"]
 	path = Python/gpgmm

--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -5,6 +5,9 @@ message("DMLX_PATH=${DMLX_PATH}")
 
 project(pydirectml)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+
 if(MSVC)
 if(MSVC_VERSION GREATER_EQUAL 1920)
 # Use C++17 on VS 16.0 (aka 2019) and later but with relaxed conformance check


### PR DESCRIPTION
Fix the "error C2027: use of undefined type '_frame'" by update to pybind11 v2.10.

Use CMAKE_CXX_STANDARD to fix CMake error "PYBIND11_CPP_STANDARD should be replaced with CMAKE_CXX_STANDARD" after update pybind11.