### PR TITLE
Dxdispatch: option to clear D3D shader caches

### DIFF
--- a/DxDispatch/CMakeLists.txt
+++ b/DxDispatch/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
-project(dxdispatch VERSION 0.13.0 LANGUAGES CXX)
+project(dxdispatch VERSION 0.14.0 LANGUAGES CXX)
 
 # ==============================================================================
 # External Libraries/Helpers

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -94,6 +94,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
             "Type of command queue/list to use ('compute' or 'direct')", 
             cxxopts::value<std::string>()->default_value("direct")
         )
+        (
+            "clear_shader_caches", 
+            "Clears D3D shader caches before running commands", 
+            cxxopts::value<bool>()
+        )
         // DxDispatch generates root signatures that are guaranteed to match HLSL source, which eliminates
         // having to write it inline in the HLSL file. DXC for Xbox precompiles shaders for Xbox (by default), 
         // but precompilation requires the root signature to be in the HLSL source itself; to allow use of the
@@ -213,6 +218,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
     if (result.count("show_dependencies"))
     {
         m_showDependencies = result["show_dependencies"].as<bool>();
+    }
+
+    if (result.count("clear_shader_caches"))
+    {
+        m_clearShaderCaches = result["clear_shader_caches"].as<bool>();
     }
 
     auto queueTypeStr = result["queue_type"].as<std::string>();

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.h
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.h
@@ -21,6 +21,7 @@ public:
     bool DebugLayersEnabled() const { return m_debugLayersEnabled; }
     TimingVerbosity GetTimingVerbosity() const { return m_timingVerbosity; }
     bool ForceDisablePrecompiledShadersOnXbox() const { return m_forceDisablePrecompiledShadersOnXbox; }
+    bool ClearShaderCaches() const { return m_clearShaderCaches; }
     const std::string& AdapterSubstring() const { return m_adapterSubstring; }
     const std::filesystem::path& ModelPath() const { return m_modelPath; }
     const std::string& HelpText() const { return m_helpText; }
@@ -48,6 +49,7 @@ private:
     bool m_debugLayersEnabled = false;
     TimingVerbosity m_timingVerbosity = TimingVerbosity::Basic;
     bool m_forceDisablePrecompiledShadersOnXbox = true;
+    bool m_clearShaderCaches = false;
     std::string m_adapterSubstring = "";
     std::filesystem::path m_modelPath;
     std::string m_pixCaptureName = "dxdispatch";

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -415,6 +415,26 @@ IDxcCompiler3* Device::GetDxcCompiler()
 }
 #endif // !DXCOMPILER_NONE
 
+void Device::ClearShaderCaches()
+{
+    constexpr D3D12_SHADER_CACHE_KIND_FLAGS cacheKinds[] = 
+    {
+        D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_D3D_CACHE_FOR_DRIVER,
+        D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_D3D_CONVERSIONS,
+        D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_DRIVER_MANAGED,
+        D3D12_SHADER_CACHE_KIND_FLAG_APPLICATION_MANAGED,
+    };
+
+    for (auto cacheKind : cacheKinds)
+    {
+        auto hr = m_d3d->ShaderCacheControl(cacheKind, D3D12_SHADER_CACHE_CONTROL_FLAG_CLEAR);
+        if (FAILED(hr))
+        {
+            LogInfo(fmt::format("Clearing cache {} failed with HRESULT {}", cacheKind, hr));
+        }
+    }
+}
+
 /*static*/ uint32_t Device::GetSizeInBytes(DML_TENSOR_DATA_TYPE dataType)
 {
     switch (dataType)

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -417,20 +417,28 @@ IDxcCompiler3* Device::GetDxcCompiler()
 
 void Device::ClearShaderCaches()
 {
-    constexpr D3D12_SHADER_CACHE_KIND_FLAGS cacheKinds[] = 
+    struct
     {
-        D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_D3D_CACHE_FOR_DRIVER,
-        D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_D3D_CONVERSIONS,
-        D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_DRIVER_MANAGED,
-        D3D12_SHADER_CACHE_KIND_FLAG_APPLICATION_MANAGED,
+        D3D12_SHADER_CACHE_KIND_FLAGS kind;
+        const char* name;
+    } caches[] =
+    {
+        { D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_D3D_CACHE_FOR_DRIVER, "D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_D3D_CACHE_FOR_DRIVER" },
+        { D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_D3D_CONVERSIONS, "D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_D3D_CONVERSIONS" },
+        { D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_DRIVER_MANAGED, "D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_DRIVER_MANAGED" },
+        { D3D12_SHADER_CACHE_KIND_FLAG_APPLICATION_MANAGED, "D3D12_SHADER_CACHE_KIND_FLAG_APPLICATION_MANAGED" },
     };
 
-    for (auto cacheKind : cacheKinds)
+    for (auto cache : caches)
     {
-        auto hr = m_d3d->ShaderCacheControl(cacheKind, D3D12_SHADER_CACHE_CONTROL_FLAG_CLEAR);
+        auto hr = m_d3d->ShaderCacheControl(cache.kind, D3D12_SHADER_CACHE_CONTROL_FLAG_CLEAR);
         if (FAILED(hr))
         {
-            LogInfo(fmt::format("Clearing cache {} failed with HRESULT {}", cacheKind, hr));
+            LogInfo(fmt::format("Clearing {} failed. Do you have developer mode enabled?", cache.name));
+        }
+        else
+        {
+            LogInfo(fmt::format("Clearing {} succeeded.", cache.name));
         }
     }
 }

--- a/DxDispatch/src/dxdispatch/Device.h
+++ b/DxDispatch/src/dxdispatch/Device.h
@@ -85,6 +85,8 @@ public:
 
     std::vector<std::byte> Download(Microsoft::WRL::ComPtr<ID3D12Resource>);
 
+    void ClearShaderCaches();
+
     static uint32_t GetSizeInBytes(DML_TENSOR_DATA_TYPE dataType);
     static DXGI_FORMAT GetDxgiFormatFromDmlTensorDataType(DML_TENSOR_DATA_TYPE dataType);
 
@@ -97,7 +99,7 @@ private:
 private:
     std::shared_ptr<PixCaptureHelper> m_pixCaptureHelper;
     std::shared_ptr<D3d12Module> m_d3dModule;
-    Microsoft::WRL::ComPtr<ID3D12Device8> m_d3d;
+    Microsoft::WRL::ComPtr<ID3D12Device9> m_d3d;
 #ifndef _GAMING_XBOX
     Microsoft::WRL::ComPtr<ID3D12InfoQueue1> m_infoQueue;
 #endif

--- a/DxDispatch/src/dxdispatch/main.cpp
+++ b/DxDispatch/src/dxdispatch/main.cpp
@@ -84,6 +84,11 @@ int main(int argc, char** argv)
             return 1;
         }
 
+        if (args.ClearShaderCaches())
+        {
+            device->ClearShaderCaches();
+        }
+
         Model model;
         try
         {


### PR DESCRIPTION
This option is useful for checking cold cache initialization time. Developer mode is required.