### PR TITLE
Support ORT extensions in DxDispatch

### DIFF
--- a/DxDispatch/CMakeLists.txt
+++ b/DxDispatch/CMakeLists.txt
@@ -55,6 +55,9 @@ include(cmake/onnxruntime.cmake)
 add_onnxruntime_target(onnxruntime CACHE_PREFIX DXD)
 get_target_property(onnxruntime_type onnxruntime DX_COMPONENT_CONFIG)
 
+include(cmake/onnxruntime_extensions.cmake)
+add_onnxruntime_extensions_target(onnxruntime_extensions CACHE_PREFIX DXD)
+
 # ==============================================================================
 # Model Library
 # ==============================================================================
@@ -94,6 +97,7 @@ get_target_property(dxcompiler_config dxcompiler DX_COMPONENT_CONFIG)
 get_target_property(pix_config pix DX_COMPONENT_CONFIG)
 get_target_property(gdk_config gdk DX_COMPONENT_CONFIG)
 get_target_property(ort_config onnxruntime DX_COMPONENT_CONFIG)
+get_target_property(ort_extensions_config onnxruntime_extensions DX_COMPONENT_CONFIG)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/dxdispatch/config.h.in config.h)
 
 add_executable(
@@ -155,6 +159,7 @@ target_link_libraries(
     gdk
     wil
     onnxruntime
+    onnxruntime_extensions
 )
 
 target_compile_features(dxdispatch PRIVATE cxx_std_17)

--- a/DxDispatch/ThirdPartyNotices.txt
+++ b/DxDispatch/ThirdPartyNotices.txt
@@ -16,7 +16,8 @@ This software incorporates third party material from the projects listed below.
 - Microsoft DirectMLX Header: https://github.com/microsoft/DirectML
 - Microsoft DirectX Headers: https://github.com/microsoft/DirectX-Headers
 - Microsoft DirectX 12 Agility SDK Redistributable NuGet Package: https://www.nuget.org/packages/Microsoft.Direct3D.D3D12
-- ONNX Runtime: https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML/1.11.0
+- ONNX Runtime: https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML/
+- ONNX Runtime Extensions: https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Extensions/
 
 -------------------------------------------------------------------------------
 cxxopts
@@ -671,3 +672,28 @@ ONNX Runtime NuGet Package
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
+
+-------------------------------------------------------------------------------
+ONNX Runtime Extensions NuGet Package
+-------------------------------------------------------------------------------
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/DxDispatch/cgmanifest.json
+++ b/DxDispatch/cgmanifest.json
@@ -119,6 +119,15 @@
           "version": "1.15.0"
         }
       }
+    },
+    {
+      "component": {
+        "type": "nuget",
+        "nuget": {
+          "name": "Microsoft.ML.OnnxRuntime.Extensions",
+          "version": "0.8.0"
+        }
+      }
     }
   ],
   "Version": 1

--- a/DxDispatch/cmake/onnxruntime_extensions.cmake
+++ b/DxDispatch/cmake/onnxruntime_extensions.cmake
@@ -1,0 +1,120 @@
+# =============================================================================
+# Helper function to introduce a target representing an ONNX Runtime extensions.
+#
+# The main function is `add_onnxruntime_extensions_target`, which has the following parameters:
+#
+# - CACHE_PREFIX : string used to prefix cache variables associated with the function.
+#
+# The following cache variables are defined after calling the main function 
+# (all variable names are prefixed with the value of CACHE_PREFIX):
+#
+# - ONNXRUNTIME_EXTENSIONS_TYPE
+#       nuget  : Use NuGet distribution of ONNX Runtime.
+#       none   : No dependency on ONNX Runtime (stub target).
+#
+# - ONNXRUNTIME_EXTENSIONS_NUGET_ID : ID of the ONNX Runtime NuGet package (TYPE == nuget).
+# - ONNXRUNTIME_EXTENSIONS_NUGET_VERSION : Version of the ONNX Runtime NuGet package (TYPE == nuget).
+# - ONNXRUNTIME_EXTENSIONS_NUGET_HASH : SHA256 hash of the ONNX Runtime NuGet package (TYPE == nuget).
+# =============================================================================
+
+include_guard()
+include(FetchContent)
+include(${CMAKE_CURRENT_LIST_DIR}/helper_platform.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/helper_redist.cmake)
+
+# -----------------------------------------------------------------------------
+# Add cache variables.
+# -----------------------------------------------------------------------------
+function(init_onnxruntime_extensions_cache_variables prefix)
+    if(NOT prefix)
+        message(FATAL_ERROR "The prefix must not be an empty string.")
+    endif()
+
+    # <PREFIX>_ONNXRUNTIME_EXTENSIONS_TYPE
+    if(TARGET_WINDOWS AND TARGET_ARCH MATCHES "^X86|X64|ARM|ARM64$")
+        set(default_type nuget)
+    else()
+        set(default_type none)
+    endif()
+    set(${prefix}_ONNXRUNTIME_EXTENSIONS_TYPE 
+        "${default_type}" 
+        CACHE STRING "ONNXRUNTIME extensions dependency type"
+    )
+    set_property(CACHE ${prefix}_ONNXRUNTIME_EXTENSIONS_TYPE PROPERTY STRINGS nuget local none)
+
+    # <PREFIX>_ONNXRUNTIME_EXTENSIONS_NUGET_ID
+    set(${prefix}_ONNXRUNTIME_EXTENSIONS_NUGET_ID
+        Microsoft.ML.OnnxRuntime.Extensions
+        CACHE STRING "ID of the ONNX Runtime NuGet package (TYPE == nuget)."
+    )
+
+    # <PREFIX>_ONNXRUNTIME_EXTENSIONS_NUGET_VERSION
+    set(${prefix}_ONNXRUNTIME_EXTENSIONS_NUGET_VERSION
+        0.8.0
+        CACHE STRING "Version of the ONNX Runtime NuGet package (TYPE == nuget)."
+    )
+
+    # <PREFIX>_ONNXRUNTIME_EXTENSIONS_NUGET_HASH
+    set(${prefix}_ONNXRUNTIME_EXTENSIONS_NUGET_HASH 
+        543276F2DBCE9C7F22641FFFE3CAD3E7B9223650B3B66D822F5F5503F53EB301
+        CACHE STRING "SHA256 hash of the ONNX Runtime NuGet package (TYPE == nuget)."
+    )
+endfunction()
+
+# -----------------------------------------------------------------------------
+# Init using a NuGet distribution.
+# -----------------------------------------------------------------------------
+function(init_onnxruntime_extensions_target_nuget target_name pkg_id pkg_version pkg_hash)
+    if(NOT (TARGET_WINDOWS AND TARGET_ARCH MATCHES "^X64|X86|ARM|ARM64$"))
+        message(FATAL_ERROR "ONNX Runtime extensions NuGet isn't available on this platform")
+    endif()
+
+    set(content ${target_name}_content)
+    FetchContent_Declare(
+        ${content}
+        URL "https://www.nuget.org/api/v2/package/${pkg_id}/${pkg_version}"
+        URL_HASH SHA256=${pkg_hash}
+    )
+    FetchContent_MakeAvailable(${content})
+
+    set(bin_path "${${content}_SOURCE_DIR}/runtimes/win-${TARGET_ARCH}")
+    target_append_redist_file(${target_name} "${bin_path}/native/ortextensions.dll")
+
+    set_property(TARGET ${target_name} PROPERTY DX_COMPONENT_CONFIG "NuGet (${pkg_id}.${pkg_version})")
+endfunction()
+
+# -----------------------------------------------------------------------------
+# Init as a stub dependency.
+# -----------------------------------------------------------------------------
+function(init_onnxruntime_extensions_target_stub target_name)
+    set_property(TARGET ${target_name} PROPERTY DX_COMPONENT_CONFIG "None")
+    target_compile_definitions(${target_name} INTERFACE ONNXRUNTIME_EXTENSIONS_NONE)
+endfunction()
+
+# -----------------------------------------------------------------------------
+# Main function to add the target.
+# -----------------------------------------------------------------------------
+function(add_onnxruntime_extensions_target target_name)
+    # Parse function args.
+    set(params CACHE_PREFIX)
+    cmake_parse_arguments(PARSE_ARGV 0 ARG "" "${params}" "")
+
+    # Parse cached args.
+    init_onnxruntime_extensions_cache_variables(${ARG_CACHE_PREFIX})
+    set(type "${${ARG_CACHE_PREFIX}_ONNXRUNTIME_EXTENSIONS_TYPE}")
+    set(nuget_id "${${ARG_CACHE_PREFIX}_ONNXRUNTIME_EXTENSIONS_NUGET_ID}")
+    set(nuget_version "${${ARG_CACHE_PREFIX}_ONNXRUNTIME_EXTENSIONS_NUGET_VERSION}")
+    set(nuget_hash "${${ARG_CACHE_PREFIX}_ONNXRUNTIME_EXTENSIONS_NUGET_HASH}")
+    set(local_path "${${ARG_CACHE_PREFIX}_ONNXRUNTIME_EXTENSIONS_LOCAL_PATH}")
+
+    # Initialize target based on type.
+    add_library(${target_name} INTERFACE)
+    string(TOLOWER "${type}" type)
+    if(type STREQUAL nuget)
+        init_onnxruntime_extensions_target_nuget(${target_name} ${nuget_id} ${nuget_version} ${nuget_hash})
+    elseif(type STREQUAL none)
+        init_onnxruntime_extensions_target_stub(${target_name})
+    else()
+        message(FATAL_ERROR "'${type}' is not a valid value for 'TYPE'.")
+    endif()
+endfunction()

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -10,11 +10,12 @@
 CommandLineArgs::CommandLineArgs(int argc, char** argv)
 {
         auto banner = fmt::format(R"({} version {}
-  DirectML     : {}
-  D3D12        : {}
-  DXCompiler   : {}
-  PIX          : {}
-  ONNX Runtime : {}
+  DirectML       : {}
+  D3D12          : {}
+  DXCompiler     : {}
+  PIX            : {}
+  ONNX Runtime   : {}
+  ORT Extensions : {}
 )",
         c_projectName, 
         c_projectVersion,
@@ -22,7 +23,8 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
         c_d3d12Config,
         c_dxcompilerConfig,
         c_pixConfig,
-        c_ortConfig);
+        c_ortConfig,
+        c_ortExtensionsConfig);
     
     cxxopts::Options options(c_projectName, banner);
     options.add_options()

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -182,6 +182,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
             "Prints verbose ONNX model binding information.",
             cxxopts::value<bool>()
         )
+        (
+            "x,enable_ort_extensions",
+            "Enable use of custom operators in ortextensions.dll.",
+            cxxopts::value<bool>()
+        )
         ;
 
     options.positional_help("<PATH_TO_MODEL>");
@@ -417,6 +422,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
     if (result.count("print_onnx_bindings")) 
     { 
         m_onnxPrintVerboseBindingInfo = result["print_onnx_bindings"].as<bool>(); 
+    }
+
+    if (result.count("enable_ort_extensions")) 
+    { 
+        m_ortExtensionsEnabled = result["enable_ort_extensions"].as<bool>(); 
     }
 
     m_helpText = options.help();

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.h
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.h
@@ -47,6 +47,7 @@ public:
     std::optional<uint32_t> GetOnnxGraphOptimizationLevel() const { return m_onnxGraphOptimizationLevel; }
     std::optional<uint32_t> GetOnnxLoggingLevel() const { return m_onnxLoggingLevel; }
     bool PrintVerboseOnnxBindingInfo() const { return m_onnxPrintVerboseBindingInfo; } 
+    bool OrtExtensionsEnabled() const { return m_ortExtensionsEnabled; }
 
 private:
     bool m_showAdapters = false;
@@ -94,4 +95,5 @@ private:
     std::optional<uint32_t> m_onnxGraphOptimizationLevel;
     std::optional<uint32_t> m_onnxLoggingLevel;
     bool m_onnxPrintVerboseBindingInfo = false;
+    bool m_ortExtensionsEnabled = false;
 };

--- a/DxDispatch/src/dxdispatch/DxModules.cpp
+++ b/DxDispatch/src/dxdispatch/DxModules.cpp
@@ -34,6 +34,15 @@ Module::Module(const char* moduleName)
 #endif
 }
 
+Module::Module(void* handle)
+{
+#ifdef WIN32
+    m_module.reset(reinterpret_cast<HMODULE>(handle));
+#else
+    m_module = handle;
+#endif
+}
+
 Module::Module(Module&& other)
 {
     m_module = std::move(other.m_module);

--- a/DxDispatch/src/dxdispatch/DxModules.h
+++ b/DxDispatch/src/dxdispatch/DxModules.h
@@ -9,6 +9,7 @@ class Module
 {
 public:
     explicit Module(const char* moduleName);
+    explicit Module(void* handle);
     Module(const Module&) = delete;
     Module(Module&& other);
     Module& operator=(Module&& other);

--- a/DxDispatch/src/dxdispatch/ModuleInfo.cpp
+++ b/DxDispatch/src/dxdispatch/ModuleInfo.cpp
@@ -105,4 +105,5 @@ void PrintDependencies()
     PrintModuleInfo("DXCompiler", GetModuleInfo(c_dxcompilerModuleName), c_dxcompilerConfig);
     PrintModuleInfo("PIX", GetModuleInfo(c_pixModuleName), c_pixConfig);
     PrintModuleInfo("ONNX Runtime", GetModuleInfo(c_ortModuleName), c_ortConfig);
+    PrintModuleInfo("ORT Extensions", GetModuleInfo(c_ortExtensionsModuleName), c_ortExtensionsConfig);
 }

--- a/DxDispatch/src/dxdispatch/ModuleInfo.h
+++ b/DxDispatch/src/dxdispatch/ModuleInfo.h
@@ -8,6 +8,7 @@
     constexpr const char* c_dxcompilerModuleName = "dxcompiler_xs.dll";
     constexpr const char* c_pixModuleName = "pixevt.dll";
     constexpr const char* c_ortModuleName = "onnxruntime.dll";
+    constexpr const char* c_ortExtensionsModuleName = nullptr;
 #elif defined(WIN32)
     constexpr const char* c_directmlModuleName = "directml.dll";
     constexpr const char* c_direct3dModuleName = "d3d12.dll";
@@ -16,6 +17,7 @@
     constexpr const char* c_dxcompilerModuleName = "dxcompiler.dll";
     constexpr const char* c_pixModuleName = "winpixeventruntime.dll";
     constexpr const char* c_ortModuleName = "onnxruntime.dll";
+    constexpr const char* c_ortExtensionsModuleName = "ortextensions.dll";
 #else
     constexpr const char* c_directmlModuleName = "libdirectml.so";
     constexpr const char* c_direct3dModuleName = "libd3d12.so";
@@ -24,6 +26,7 @@
     constexpr const char* c_dxcompilerModuleName = nullptr;
     constexpr const char* c_pixModuleName = nullptr;
     constexpr const char* c_ortModuleName = nullptr;
+    constexpr const char* c_ortExtensionsModuleName = nullptr;
 #endif
 
 struct ModuleInfo

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -203,6 +203,14 @@ void OnnxDispatchable::Initialize()
     sessionOptions.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
     sessionOptions.DisableMemPattern();
 
+    if (m_args.OrtExtensionsEnabled())
+    {
+        void* handle = nullptr;
+        Ort::ThrowOnError(ortApi.RegisterCustomOpsLibrary(sessionOptions, "ortextensions.dll", &handle));
+        m_ortExtensionsModule.emplace(handle);
+        handle = nullptr;
+    }
+
     GraphOptimizationLevel graphOptimizationLevel = m_args.GetOnnxGraphOptimizationLevel() ? 
         static_cast<GraphOptimizationLevel>(*m_args.GetOnnxGraphOptimizationLevel()) :
         static_cast<GraphOptimizationLevel>(m_desc.graphOptimizationLevel);

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -208,7 +208,7 @@ void OnnxDispatchable::Initialize()
         // NOTE: ORT appears to free the library, despite API comments suggesting otherwise, so the handle isn't used
         // or stored to avoid a double free.
         void* handle = nullptr;
-        Ort::ThrowOnError(ortApi.RegisterCustomOpsLibrary(sessionOptions, "ortextensions.dll", &handle));
+        Ort::ThrowOnError(ortApi.RegisterCustomOpsLibrary(sessionOptions, c_ortExtensionsModuleName, &handle));
     }
 
     GraphOptimizationLevel graphOptimizationLevel = m_args.GetOnnxGraphOptimizationLevel() ? 

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -205,10 +205,10 @@ void OnnxDispatchable::Initialize()
 
     if (m_args.OrtExtensionsEnabled())
     {
+        // NOTE: ORT appears to free the library, despite API comments suggesting otherwise, so the handle isn't used
+        // or stored to avoid a double free.
         void* handle = nullptr;
         Ort::ThrowOnError(ortApi.RegisterCustomOpsLibrary(sessionOptions, "ortextensions.dll", &handle));
-        m_ortExtensionsModule.emplace(handle);
-        handle = nullptr;
     }
 
     GraphOptimizationLevel graphOptimizationLevel = m_args.GetOnnxGraphOptimizationLevel() ? 

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.h
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.h
@@ -42,6 +42,4 @@ private:
     std::vector<TensorBinding> m_mergedBindings;
 
     std::optional<Ort::IoBinding> m_ioBindings;
-
-    std::optional<Module> m_ortExtensionsModule;
 };

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.h
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.h
@@ -42,4 +42,6 @@ private:
     std::vector<TensorBinding> m_mergedBindings;
 
     std::optional<Ort::IoBinding> m_ioBindings;
+
+    std::optional<Module> m_ortExtensionsModule;
 };

--- a/DxDispatch/src/dxdispatch/config.h.in
+++ b/DxDispatch/src/dxdispatch/config.h.in
@@ -9,3 +9,4 @@ static constexpr auto c_dxcompilerConfig = "@dxcompiler_config@";
 static constexpr auto c_pixConfig = "@pix_config@";
 static constexpr auto c_gdkConfig = "@gdk_config@";
 static constexpr auto c_ortConfig = "@ort_config@";
+static constexpr auto c_ortExtensionsConfig = "@ort_extensions_config@";


### PR DESCRIPTION
Adds support for running ONNX models with a dependency on ortextensions.dll. This library is not enabled by default, so you must supply `--enable_ort_extensions` when running the model.