### PR TITLE
Add profiling option to DxDispatch

### DIFF
--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -187,6 +187,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
             "Enable use of custom operators in ortextensions.dll.",
             cxxopts::value<bool>()
         )
+        (
+            "enable_profiling",
+            "Captures a json file of the CPU and GPU execution that can be viewed in a chromium-based browser.",
+            cxxopts::value<bool>()
+        )
         ;
 
     options.positional_help("<PATH_TO_MODEL>");
@@ -427,6 +432,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
     if (result.count("enable_ort_extensions")) 
     { 
         m_ortExtensionsEnabled = result["enable_ort_extensions"].as<bool>(); 
+    }
+
+    if (result.count("enable_profiling"))
+    {
+        m_profilingEnabled = result["enable_profiling"].as<bool>();
     }
 
     m_helpText = options.help();

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -188,7 +188,7 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
             cxxopts::value<bool>()
         )
         (
-            "enable_profiling",
+            "enable_onnx_profiling",
             "Captures a json file of the CPU and GPU execution that can be viewed in a chromium-based browser.",
             cxxopts::value<bool>()
         )
@@ -434,9 +434,9 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
         m_ortExtensionsEnabled = result["enable_ort_extensions"].as<bool>(); 
     }
 
-    if (result.count("enable_profiling"))
+    if (result.count("enable_onnx_profiling"))
     {
-        m_profilingEnabled = result["enable_profiling"].as<bool>();
+        m_onnxProfilingEnabled = result["enable_onnx_profiling"].as<bool>();
     }
 
     m_helpText = options.help();

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.h
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.h
@@ -48,7 +48,7 @@ public:
     std::optional<uint32_t> GetOnnxLoggingLevel() const { return m_onnxLoggingLevel; }
     bool PrintVerboseOnnxBindingInfo() const { return m_onnxPrintVerboseBindingInfo; } 
     bool OrtExtensionsEnabled() const { return m_ortExtensionsEnabled; }
-    bool ProfilingEnabled() const { return m_profilingEnabled; }
+    bool OnnxProfilingEnabled() const { return m_onnxProfilingEnabled; }
 
 private:
     bool m_showAdapters = false;
@@ -97,5 +97,5 @@ private:
     std::optional<uint32_t> m_onnxLoggingLevel;
     bool m_onnxPrintVerboseBindingInfo = false;
     bool m_ortExtensionsEnabled = false;
-    bool m_profilingEnabled = false;
+    bool m_onnxProfilingEnabled = false;
 };

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.h
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.h
@@ -48,6 +48,7 @@ public:
     std::optional<uint32_t> GetOnnxLoggingLevel() const { return m_onnxLoggingLevel; }
     bool PrintVerboseOnnxBindingInfo() const { return m_onnxPrintVerboseBindingInfo; } 
     bool OrtExtensionsEnabled() const { return m_ortExtensionsEnabled; }
+    bool ProfilingEnabled() const { return m_profilingEnabled; }
 
 private:
     bool m_showAdapters = false;
@@ -96,4 +97,5 @@ private:
     std::optional<uint32_t> m_onnxLoggingLevel;
     bool m_onnxPrintVerboseBindingInfo = false;
     bool m_ortExtensionsEnabled = false;
+    bool m_profilingEnabled = false;
 };

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -203,7 +203,7 @@ void OnnxDispatchable::Initialize()
     sessionOptions.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
     sessionOptions.DisableMemPattern();
 
-    if (m_args.ProfilingEnabled())
+    if (m_args.OnnxProfilingEnabled())
     {
         sessionOptions.EnableProfiling(L"DxDispatch");
     }

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -203,6 +203,11 @@ void OnnxDispatchable::Initialize()
     sessionOptions.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
     sessionOptions.DisableMemPattern();
 
+    if (m_args.ProfilingEnabled())
+    {
+        sessionOptions.EnableProfiling(L"DxDispatch");
+    }
+
     if (m_args.OrtExtensionsEnabled())
     {
         // NOTE: ORT appears to free the library, despite API comments suggesting otherwise, so the handle isn't used


### PR DESCRIPTION
This is the profiling option that generates a .json trace that can be viewed in chromium browser. It doesn't contain useful perf information for DirectML since it captures only the CPU timeline, but it makes it easy to see the partitioning at a glance and which ops are falling back to the CPU, if any.