### PR TITLE
Fix two issues in VisionTransformer

### DIFF
--- a/TensorFlow/TF1/VisionTransformer/model.py
+++ b/TensorFlow/TF1/VisionTransformer/model.py
@@ -65,7 +65,7 @@ class PatchExtractEncoder(tf.keras.layers.Layer):
         patches = tf.image.extract_patches(
             images=images,
             sizes=[1, self.patch_size, self.patch_size, 1],
-            strides=[1, self.patch_size, self.patch_size, 1],
+            strides=[1, self.patch_stride, self.patch_stride, 1],
             rates=[1, 1, 1, 1],
             padding="VALID",
         )

--- a/TensorFlow/TF1/VisionTransformer/train_cifar10.py
+++ b/TensorFlow/TF1/VisionTransformer/train_cifar10.py
@@ -91,7 +91,7 @@ callbacks_list = [checkpoint, reduce_on_plateau]
 model.fit(
     get_train_dataset(train_dataset),
     validation_data=validation_dataset,
-    validation_steps=10,
+    validation_steps=min(10, len(validation_dataset)),
     epochs=EPOCHS,
     callbacks=callbacks_list,
 )

--- a/TensorFlow/TF1/VisionTransformer/train_cifar100.py
+++ b/TensorFlow/TF1/VisionTransformer/train_cifar100.py
@@ -91,7 +91,7 @@ callbacks_list = [checkpoint, reduce_on_plateau]
 model.fit(
     get_train_dataset(train_dataset),
     validation_data=validation_dataset,
-    validation_steps=10,
+    validation_steps=min(10, len(validation_dataset)),
     epochs=EPOCHS,
     callbacks=callbacks_list,
 )

--- a/TensorFlow/TF2/VisionTransformer/model.py
+++ b/TensorFlow/TF2/VisionTransformer/model.py
@@ -63,7 +63,7 @@ class PatchExtractEncoder(tf.keras.layers.Layer):
         patches = tf.image.extract_patches(
             images=images,
             sizes=[1, self.patch_size, self.patch_size, 1],
-            strides=[1, self.patch_size, self.patch_size, 1],
+            strides=[1, self.patch_stride, self.patch_stride, 1],
             rates=[1, 1, 1, 1],
             padding="VALID",
         )

--- a/TensorFlow/TF2/VisionTransformer/train_cifar10.py
+++ b/TensorFlow/TF2/VisionTransformer/train_cifar10.py
@@ -9,7 +9,7 @@ from data_augmentations import random_hue_saturation, random_brightness_contrast
 AUTOTUNE = tf.data.experimental.AUTOTUNE
 
 if __name__ == "__main__":
-    
+
     #You can uncomment the below line to view DirectML Device Placement logs for the model's operators
     #tf.debugging.set_log_device_placement(True) 
 
@@ -88,7 +88,7 @@ callbacks_list = [checkpoint, reduce_on_plateau]
 model.fit(
     get_train_dataset(train_dataset),
     validation_data=validation_dataset,
-    validation_steps=10,
+    validation_steps=min(10, len(validation_dataset)),
     epochs=EPOCHS,
     callbacks=callbacks_list,
 )

--- a/TensorFlow/TF2/VisionTransformer/train_cifar100.py
+++ b/TensorFlow/TF2/VisionTransformer/train_cifar100.py
@@ -88,7 +88,7 @@ callbacks_list = [checkpoint, reduce_on_plateau]
 model.fit(
     get_train_dataset(train_dataset),
     validation_data=validation_dataset,
-    validation_steps=10,
+    validation_steps=min(10, len(validation_dataset)),
     epochs=EPOCHS,
     callbacks=callbacks_list,
 )


### PR DESCRIPTION
* I believe patch_stride should be used in tf.image.extract_patches function call. I tried different patch_stride, results are not expected.
* if BATCH_SIZE is large, there may be not enough batches in validation_dataset, following warnings will be generated and validation will fail. No "val_Top-1-accuracy" metric is available and no best model will be saved except for first epoch.
```
WARNING:tensorflow:Your input ran out of data; interrupting training. Make sure that your dataset or generator can generate at least `steps_per_epoch * epochs` batches (in this case, 10 batches). You may need to use the repeat() function when building your dataset.
```
```
WARNING:tensorflow:Learning rate reduction is conditioned on metric `val_Top-1-accuracy` which is not available. Available metrics are: loss,Top-1-accuracy,Top-3-accuracy,lr
```