### PR TITLE
Add support for 3d operators

### DIFF
--- a/DxDispatch/models/dml_convolution.json
+++ b/DxDispatch/models/dml_convolution.json
@@ -40,6 +40,25 @@
                 "OutputPadding": [0,0],
                 "GroupCount": 1
             }
+        },
+        "conv3d": 
+        {
+            "type": "DML_OPERATOR_CONVOLUTION",
+            "desc": 
+            {
+                "InputTensor": { "DataType": "FLOAT32", "Sizes": [1,1,3,3,3] },
+                "FilterTensor": { "DataType": "FLOAT32", "Sizes": [1,1,2,2,2] },
+                "OutputTensor": { "DataType": "FLOAT32", "Sizes": [1,1,2,2,2] },
+                "Mode": "DML_CONVOLUTION_MODE_CROSS_CORRELATION",
+                "Direction": "DML_CONVOLUTION_DIRECTION_FORWARD",
+                "DimensionCount": 3,
+                "Strides": [1,1,1],
+                "Dilations": [1,1,1],
+                "StartPadding": [0,0,0],
+                "EndPadding": [0,0,0],
+                "OutputPadding": [0,0,0],
+                "GroupCount": 1
+            }
         }
     },
 
@@ -48,6 +67,16 @@
         {
             "type": "dispatch",
             "dispatchable": "conv2d",
+            "bindings":
+            {
+                "InputTensor": "input",
+                "FilterTensor": "filter",
+                "OutputTensor": "output"
+            }
+        },
+        {
+            "type": "dispatch",
+            "dispatchable": "conv3d",
             "bindings":
             {
                 "InputTensor": "input",

--- a/DxDispatch/models/dml_upsample_3d.json
+++ b/DxDispatch/models/dml_upsample_3d.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "./_schema.json",
+    
+    "resources": 
+    {
+        "input":
+        {
+            "initialValuesDataType": "FLOAT32",
+            "initialValues": { "valueCount": 4, "valueStart": 1, "valueDelta": 1 }
+        },
+        "output":
+        {
+            "initialValuesDataType": "FLOAT32",
+            "initialValues": { "valueCount": 16, "value": 0 }
+        }
+    },
+
+    "dispatchables": 
+    {
+        "upsample":
+        {
+            "type": "DML_OPERATOR_UPSAMPLE_3D",
+            "desc": 
+            {
+                "InputTensor": { "DataType": "FLOAT32", "Sizes": [1,1,2,2,2] },
+                "OutputTensor": { "DataType": "FLOAT32", "Sizes": [1,1,4,4,4] },
+                "ScaleSize": { "Width": 2, "Height": 2 , "Depth": 2},
+                "InterpolationMode": "DML_INTERPOLATION_MODE_LINEAR"
+            }
+        }
+    },
+
+    "commands": 
+    [
+        {
+            "type": "dispatch",
+            "dispatchable": "upsample",
+            "bindings": 
+            {
+                "InputTensor": "input",
+                "OutputTensor": "output"
+            }
+        },
+        { "type": "print", "resource": "output" }
+    ]
+}

--- a/DxDispatch/src/model/JsonParsers.cpp
+++ b/DxDispatch/src/model/JsonParsers.cpp
@@ -702,6 +702,40 @@ DML_SIZE_2D* ParseDmlSize2dField(const rapidjson::Value& object, std::string_vie
 }
 
 // ----------------------------------------------------------------------------
+// DML_SIZE_3D
+// ----------------------------------------------------------------------------
+static void ParseDmlSize3d(const rapidjson::Value& value, DML_SIZE_3D& returnValue)
+{
+    if (!value.IsObject())
+    {
+        throw std::invalid_argument("Expected a non-null JSON object.");
+    }
+    returnValue.Width = ParseUInt32Field(value, "Width");
+    returnValue.Height = ParseUInt32Field(value, "Height");
+}
+
+DML_SIZE_3D ParseDmlSize3d(const rapidjson::Value& value)
+{
+    DML_SIZE_3D returnValue = {};
+    ParseDmlSize3d(value, returnValue);
+    return returnValue;
+}
+
+DML_SIZE_3D* ParseDmlSize3d(const rapidjson::Value& value, BucketAllocator& allocator)
+{
+    auto returnValue = allocator.Allocate<DML_SIZE_3D>();
+    ParseDmlSize3d(value, *returnValue);
+    return returnValue;
+}
+
+DML_SIZE_3D* ParseDmlSize3dField(const rapidjson::Value& object, std::string_view fieldName, BucketAllocator& allocator, bool required, DML_SIZE_3D* defaultValue)
+{
+    return ParseFieldHelper<DML_SIZE_3D*>(object, fieldName, required, defaultValue, [&allocator](auto& value){ 
+        return ParseDmlSize3d(value, allocator); 
+    });
+}
+
+// ----------------------------------------------------------------------------
 // DML_SCALAR_UNION
 // ----------------------------------------------------------------------------
 static void ParseDmlScalarUnion(const rapidjson::Value& value, DML_TENSOR_DATA_TYPE dataType, DML_SCALAR_UNION& returnValue)

--- a/DxDispatch/src/model/JsonParsers.h
+++ b/DxDispatch/src/model/JsonParsers.h
@@ -101,6 +101,11 @@ namespace JsonParsers
     DML_SIZE_2D* ParseDmlSize2d(const rapidjson::Value& value, BucketAllocator& allocator);
     DML_SIZE_2D* ParseDmlSize2dField(const rapidjson::Value& object, std::string_view fieldName, BucketAllocator& allocator, bool required = true, DML_SIZE_2D* defaultValue = nullptr);
 
+    // DML_SIZE_3D
+    DML_SIZE_3D ParseDmlSize3d(const rapidjson::Value& value);
+    DML_SIZE_3D* ParseDmlSize3d(const rapidjson::Value& value, BucketAllocator& allocator);
+    DML_SIZE_3D* ParseDmlSize3dField(const rapidjson::Value& object, std::string_view fieldName, BucketAllocator& allocator, bool required = true, DML_SIZE_3D* defaultValue = nullptr);
+
     // DML_SCALAR_UNION
     DML_SCALAR_UNION ParseDmlScalarUnion(const rapidjson::Value& value, DML_TENSOR_DATA_TYPE dataType);
     DML_SCALAR_UNION* ParseDmlScalarUnion(const rapidjson::Value& value, DML_TENSOR_DATA_TYPE dataType, BucketAllocator& allocator);

--- a/DxDispatch/src/model/JsonParsersGenerated.cpp
+++ b/DxDispatch/src/model/JsonParsersGenerated.cpp
@@ -1956,6 +1956,21 @@ DML_OPERATOR_DESC* ParseDmlValueScale2dOperatorDesc(const rapidjson::Value& valu
     opDesc->Desc = desc;
     return opDesc;
 }
+
+DML_OPERATOR_DESC* ParseDmlValueScale3dOperatorDesc(const rapidjson::Value& value, bool fused, BucketAllocator& allocator)
+{
+    if (!value.IsObject()) { throw std::invalid_argument("Expected a valid JSON object."); }
+    auto desc = allocator.Allocate<DML_VALUE_SCALE_3D_OPERATOR_DESC>();
+    desc->InputTensor = fused ? nullptr : ParseDmlTensorDescField(value, "InputTensor", allocator, true);
+    desc->OutputTensor = fused ? nullptr : ParseDmlTensorDescField(value, "OutputTensor", allocator, true);
+    desc->Scale = ParseFloat32Field(value, "Scale", true);
+    desc->ChannelCount = ParseUInt32Field(value, "ChannelCount", true);
+    desc->Bias = AsPointer(ParseFloat32ArrayField(value, "Bias", allocator, true));
+    auto opDesc = allocator.Allocate<DML_OPERATOR_DESC>();
+    opDesc->Type = DML_OPERATOR_VALUE_SCALE_3D;
+    opDesc->Desc = desc;
+    return opDesc;
+}
  
 Model::DmlDispatchableDesc::BindPoints GetBindPoints(const DML_VALUE_SCALE_2D_OPERATOR_DESC& desc)
 {
@@ -1975,6 +1990,20 @@ DML_OPERATOR_DESC* ParseDmlUpsample2dOperatorDesc(const rapidjson::Value& value,
     desc->InterpolationMode = ParseDmlInterpolationModeField(value, "InterpolationMode", true, {});
     auto opDesc = allocator.Allocate<DML_OPERATOR_DESC>();
     opDesc->Type = DML_OPERATOR_UPSAMPLE_2D;
+    opDesc->Desc = desc;
+    return opDesc;
+}
+ 
+DML_OPERATOR_DESC* ParseDmlUpsample3dOperatorDesc(const rapidjson::Value& value, bool fused, BucketAllocator& allocator)
+{
+    if (!value.IsObject()) { throw std::invalid_argument("Expected a valid JSON object."); }
+    auto desc = allocator.Allocate<DML_UPSAMPLE_3D_OPERATOR_DESC>();
+    desc->InputTensor = fused ? nullptr : ParseDmlTensorDescField(value, "InputTensor", allocator, true);
+    desc->OutputTensor = fused ? nullptr : ParseDmlTensorDescField(value, "OutputTensor", allocator, true);
+    desc->ScaleSize = *ParseDmlSize3dField(value, "ScaleSize", allocator, true);
+    desc->InterpolationMode = ParseDmlInterpolationModeField(value, "InterpolationMode", true, {});
+    auto opDesc = allocator.Allocate<DML_OPERATOR_DESC>();
+    opDesc->Type = DML_OPERATOR_UPSAMPLE_3D;
     opDesc->Desc = desc;
     return opDesc;
 }
@@ -4646,6 +4675,8 @@ DML_OPERATOR_DESC* ParseDmlOperatorDesc(const rapidjson::Value& value, bool fuse
     if (!strcmp(type, "DML_OPERATOR_PADDING1") || !strcmp(type, "PADDING1")) return ParseDmlPadding1OperatorDesc(descValue, fused, allocator);
     if (!strcmp(type, "DML_OPERATOR_VALUE_SCALE_2D") || !strcmp(type, "VALUE_SCALE_2D")) return ParseDmlValueScale2dOperatorDesc(descValue, fused, allocator);
     if (!strcmp(type, "DML_OPERATOR_UPSAMPLE_2D") || !strcmp(type, "UPSAMPLE_2D")) return ParseDmlUpsample2dOperatorDesc(descValue, fused, allocator);
+    if (!strcmp(type, "DML_OPERATOR_VALUE_SCALE_3D") || !strcmp(type, "VALUE_SCALE_3D")) return ParseDmlValueScale3dOperatorDesc(descValue, fused, allocator);
+    if (!strcmp(type, "DML_OPERATOR_UPSAMPLE_3D") || !strcmp(type, "UPSAMPLE_3D")) return ParseDmlUpsample3dOperatorDesc(descValue, fused, allocator);
     if (!strcmp(type, "DML_OPERATOR_GATHER") || !strcmp(type, "GATHER")) return ParseDmlGatherOperatorDesc(descValue, fused, allocator);
     if (!strcmp(type, "DML_OPERATOR_SPACE_TO_DEPTH") || !strcmp(type, "SPACE_TO_DEPTH")) return ParseDmlSpaceToDepthOperatorDesc(descValue, fused, allocator);
     if (!strcmp(type, "DML_OPERATOR_DEPTH_TO_SPACE") || !strcmp(type, "DEPTH_TO_SPACE")) return ParseDmlDepthToSpaceOperatorDesc(descValue, fused, allocator);

--- a/DxDispatch/src/test/JsonParserTests.cpp
+++ b/DxDispatch/src/test/JsonParserTests.cpp
@@ -1213,6 +1213,55 @@ TEST(ParseDmlSize2dTest, MissingField)
 }
 
 // ----------------------------------------------------------------------------
+// DML_SIZE_3D
+// ----------------------------------------------------------------------------
+
+TEST(ParseDmlSize3dTest, ValidInput) 
+{
+    Document d;
+    d.Parse(R"({
+        "x0": { "Width": 4, "Height": 15 }
+    })");
+    ASSERT_FALSE(d.HasParseError());
+
+    auto result = ParseDmlSize3d(d["x0"]);
+    EXPECT_EQ(result.Width, 4);
+    EXPECT_EQ(result.Height, 15);
+
+    BucketAllocator allocator;
+    auto result2 = ParseDmlSize3dField(d, "x0", allocator);
+    EXPECT_EQ(result2->Width, 4);
+    EXPECT_EQ(result2->Height, 15);
+}
+
+TEST(ParseDmlSize3dTest, InvalidInput) 
+{
+    Document d;
+    d.Parse(R"({
+        "x0": { "Width": 4.2, "Height": 15.1 },
+        "x1": null,
+        "x2": "cat",
+        "x3": [],
+        "x4": 5
+    })");
+    ASSERT_FALSE(d.HasParseError());
+    for (auto field = d.MemberBegin(); field < d.MemberEnd(); field++)
+    {
+        EXPECT_THROW(ParseDmlTensorDataType(field->value), std::invalid_argument);
+    }
+}
+
+TEST(ParseDmlSize3dTest, MissingField) 
+{
+    Document d;
+    d.Parse(R"({})");
+    ASSERT_FALSE(d.HasParseError());
+    BucketAllocator allocator;
+    EXPECT_EQ(ParseDmlSize3dField(d, "x0", allocator, false, nullptr), nullptr);
+    EXPECT_THROW(ParseDmlSize3dField(d, "x0", allocator), std::invalid_argument);
+}
+
+// ----------------------------------------------------------------------------
 // DML_SCALAR_UNION
 // ----------------------------------------------------------------------------
 

--- a/Python/src/module.cpp
+++ b/Python/src/module.cpp
@@ -375,6 +375,11 @@ PYBIND11_MODULE(pydirectml, module)
         py::arg("scale_size"),
         py::arg("interpolation_mode"));
 
+    module.def("up_sample_3d", &dml::Upsample3D, "Create a two-dimensional up-sample expression.",
+        py::arg("input"),
+        py::arg("scale_size"),
+        py::arg("interpolation_mode"));
+
     module.def("activation_relu", &dml::ActivationRelu, "Takes an input tensor and applies the function output = max(0, input) across its elements.",
         py::arg("input"));
 
@@ -457,6 +462,17 @@ PYBIND11_MODULE(pydirectml, module)
             return dml::ValueScale2D(input, scale, bias);
         },
         "Scales and bias the input image per pixel. output = input * scale + bias[C]",
+        py::arg("input"),
+        py::arg("scale"),
+        py::arg("bias"));
+
+    module.def("value_scale_3d", [](
+        dml::Expression input,
+        float scale,
+        std::vector<float> bias) {
+            return dml::ValueScale3D(input, scale, bias);
+        },
+        "Scales and bias the input video per pixel. output = input * scale + bias[C]",
         py::arg("input"),
         py::arg("scale"),
         py::arg("bias"));


### PR DESCRIPTION
I'm guessing that the upsampling commit is invalid because I don't find the corresponding operator [here](https://learn.microsoft.com/en-us/windows/win32/api/directml/ne-directml-dml_operator_type). But could we merge the 3d conv and size parsing parts ?