### PR TITLE
Update CMakeLists.txt warning level WX to WX- to avoid build failure.

### DIFF
--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -34,7 +34,7 @@ pybind11_add_module(
     src/device.cpp
     )
 
-target_compile_options(pydirectml PRIVATE /W4 /WX)
+target_compile_options(pydirectml PRIVATE /W4 /WX-)
 target_include_directories(pydirectml PRIVATE pybind11/include gpgmm/src/include gpgmm/ ${DML_PATH}/include ${DMLX_PATH})
 target_link_directories(pydirectml PRIVATE ${DML_PATH}/bin/x64-win)
 target_link_libraries(pydirectml PRIVATE gpgmm dxgi.lib d3d12.lib directml.lib)


### PR DESCRIPTION
some warnings in latest DirectMLX like "warning C4189: 'spatialDimensionCount': local variable is initialized but not referenced " will be treated in building pydirectml. set warning level WX to WX- to avoid failure