### PR TITLE
[DirectMLX] Fixed the local variable initialized but not referenced issue.

### DIFF
--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -2147,11 +2147,12 @@ namespace dml
         detail::GraphBuilder* builder = input.Impl()->GetGraphBuilder();
 
         TensorDesc inputTensor = input.Impl()->GetOutputDesc();
+
+#if DML_TARGET_VERSION >= 0x6200
         const uint32_t defaultStridesAndDilations[3] = { 1, 1, 1 };
         uint32_t dimensionCount = static_cast<uint32_t>(inputTensor.sizes.size());
         uint32_t spatialDimensionCount = dimensionCount - 2;
 
-#if DML_TARGET_VERSION >= 0x6200
         DML_AVERAGE_POOLING1_OPERATOR_DESC averagePoolDesc = {};
         assert(dilations.empty() || dilations.size() == spatialDimensionCount);
         averagePoolDesc.Dilations = dilations.empty() ? defaultStridesAndDilations : dilations.data();


### PR DESCRIPTION
When DML_TARGET_VERSION is less than 0x6200.