### PR TITLE
DxDispatch profiling improvements

### DIFF
--- a/DxDispatch/CMakeLists.txt
+++ b/DxDispatch/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
-project(dxdispatch VERSION 0.16.2 LANGUAGES CXX)
+project(dxdispatch VERSION 0.16.3 LANGUAGES CXX)
 
 # ==============================================================================
 # External Libraries/Helpers

--- a/DxDispatch/README.md
+++ b/DxDispatch/README.md
@@ -63,10 +63,15 @@ Alternatively, build from the command line by using `--build` option and appendi
 > cmake --build --preset <configure_preset_name>-(release|debug)
 ```
 
-To run tests, change your working directory to the build folder and execute `ctest` (only supported on some platforms). You need to specify the build configuration (release or debug) since the presets use VS, which is a multi-configuration generator:
+To run tests, change your working directory to the build folder and execute `ctest` (only supported on some platforms). You need to specify the build configuration (relwithdebinfo or debug) since the presets use VS, which is a multi-configuration generator:
 ```
 > cd build\<configure_preset_name>
-> ctest -C Release .
+
+# Test release config
+> ctest -C RelWithDebInfo .
+
+# Test debug config
+> ctest -C Debug .
 ```
 
 # Build Configuration

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -133,12 +133,12 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
         )
         (
             "disable_background_processing", 
-            "Disallows UMD from performing PGO in background threads", 
+            "Disallows UMD from performing PGO in background threads. Requires developer mode.", 
             cxxopts::value<bool>()
         )
         (
             "set_stable_power_state", 
-            "Sets a device clock rate that may be lower than the maximum but more stable", 
+            "Sets a device clock rate that may be lower than the maximum but more stable. Requires developer mode.", 
             cxxopts::value<bool>()
         )
         (

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -92,6 +92,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
             "Timing verbosity level. 0 = show hot timings, 1 = init/cold/hot timings, 2 = show all timing info",
             cxxopts::value<uint32_t>()->default_value("0")
         )
+        (
+            "max_gpu_time_measurements",
+            "Determines the size of the GPU timestamp buffer. A value of 0 will disable GPU timing.",
+            cxxopts::value<uint32_t>()
+        )
         ;
 
     // DIRECTX OPTIONS
@@ -290,6 +295,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
     if (result.count("timing_verbosity"))
     {
         m_timingVerbosity = static_cast<TimingVerbosity>(result["timing_verbosity"].as<uint32_t>());
+    }
+
+    if (result.count("max_gpu_time_measurements"))
+    {
+        m_maxGpuTimeMeasurements = result["max_gpu_time_measurements"].as<uint32_t>();
     }
 
     if (result.count("show_dependencies"))

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -127,6 +127,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
             cxxopts::value<bool>()
         )
         (
+            "disable_gpu_timeout", 
+            "Sets D3D12_COMMAND_QUEUE_FLAG_DISABLE_GPU_TIMEOUT on the command queue", 
+            cxxopts::value<bool>()
+        )
+        (
             "disable_background_processing", 
             "Disallows UMD from performing PGO in background threads", 
             cxxopts::value<bool>()
@@ -310,6 +315,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
     if (result.count("clear_shader_caches"))
     {
         m_clearShaderCaches = result["clear_shader_caches"].as<bool>();
+    }
+
+    if (result.count("disable_gpu_timeout"))
+    {
+        m_disableGpuTimeout = result["disable_gpu_timeout"].as<bool>();
     }
 
     if (result.count("disable_background_processing"))

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -122,6 +122,16 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
             cxxopts::value<bool>()
         )
         (
+            "disable_background_processing", 
+            "Disallows UMD from performing PGO in background threads", 
+            cxxopts::value<bool>()
+        )
+        (
+            "set_stable_power_state", 
+            "Sets a device clock rate that may be lower than the maximum but more stable", 
+            cxxopts::value<bool>()
+        )
+        (
             "disable_agility_sdk", 
             "Force use of the system version of D3D12Core.dll", 
             cxxopts::value<bool>()
@@ -277,7 +287,6 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
         m_outputRelPath = result["output_path"].as<std::filesystem::path>();
     }
 
-
     if (result.count("timing_verbosity"))
     {
         m_timingVerbosity = static_cast<TimingVerbosity>(result["timing_verbosity"].as<uint32_t>());
@@ -291,6 +300,16 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
     if (result.count("clear_shader_caches"))
     {
         m_clearShaderCaches = result["clear_shader_caches"].as<bool>();
+    }
+
+    if (result.count("disable_background_processing"))
+    {
+        m_disableBackgroundProcessing = result["disable_background_processing"].as<bool>();
+    }
+
+    if (result.count("set_stable_power_state"))
+    {
+        m_setStablePowerState = result["set_stable_power_state"].as<bool>();
     }
 
     if (result.count("disable_agility_sdk"))

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.h
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.h
@@ -23,6 +23,8 @@ public:
     TimingVerbosity GetTimingVerbosity() const { return m_timingVerbosity; }
     bool ForceDisablePrecompiledShadersOnXbox() const { return m_forceDisablePrecompiledShadersOnXbox; }
     bool ClearShaderCaches() const { return m_clearShaderCaches; }
+    bool DisableBackgroundProcessing() const { return m_disableBackgroundProcessing; }
+    bool SetStablePowerState() const { return m_setStablePowerState; }
     bool DisableAgilitySDK() const { return m_disableAgilitySDK; }
     const std::string& AdapterSubstring() const { return m_adapterSubstring; }
 
@@ -72,6 +74,8 @@ private:
     TimingVerbosity m_timingVerbosity = TimingVerbosity::Basic;
     bool m_forceDisablePrecompiledShadersOnXbox = true;
     bool m_clearShaderCaches = false;
+    bool m_disableBackgroundProcessing = false;
+    bool m_setStablePowerState = false;
     bool m_disableAgilitySDK = false;
     bool m_uavBarrierAfterDispatch = true;
     bool m_aliasingBarrierAfterDispatch = false;

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.h
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.h
@@ -21,6 +21,7 @@ public:
     bool PrintHlslDisassembly() const { return m_printHlslDisassembly; }
     bool DebugLayersEnabled() const { return m_debugLayersEnabled; }
     TimingVerbosity GetTimingVerbosity() const { return m_timingVerbosity; }
+    uint32_t MaxGpuTimeMeasurements() const { return m_maxGpuTimeMeasurements; }
     bool ForceDisablePrecompiledShadersOnXbox() const { return m_forceDisablePrecompiledShadersOnXbox; }
     bool ClearShaderCaches() const { return m_clearShaderCaches; }
     bool DisableBackgroundProcessing() const { return m_disableBackgroundProcessing; }
@@ -72,6 +73,7 @@ private:
     bool m_printHlslDisassembly = false;
     bool m_debugLayersEnabled = false;
     TimingVerbosity m_timingVerbosity = TimingVerbosity::Basic;
+    uint32_t m_maxGpuTimeMeasurements = 8192;
     bool m_forceDisablePrecompiledShadersOnXbox = true;
     bool m_clearShaderCaches = false;
     bool m_disableBackgroundProcessing = false;

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.h
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.h
@@ -24,6 +24,7 @@ public:
     uint32_t MaxGpuTimeMeasurements() const { return m_maxGpuTimeMeasurements; }
     bool ForceDisablePrecompiledShadersOnXbox() const { return m_forceDisablePrecompiledShadersOnXbox; }
     bool ClearShaderCaches() const { return m_clearShaderCaches; }
+    bool DisableGpuTimeout() const { return m_disableGpuTimeout; }
     bool DisableBackgroundProcessing() const { return m_disableBackgroundProcessing; }
     bool SetStablePowerState() const { return m_setStablePowerState; }
     bool DisableAgilitySDK() const { return m_disableAgilitySDK; }
@@ -76,6 +77,7 @@ private:
     uint32_t m_maxGpuTimeMeasurements = 8192;
     bool m_forceDisablePrecompiledShadersOnXbox = true;
     bool m_clearShaderCaches = false;
+    bool m_disableGpuTimeout = false;
     bool m_disableBackgroundProcessing = false;
     bool m_setStablePowerState = false;
     bool m_disableAgilitySDK = false;

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -114,6 +114,7 @@ Device::Device(
         IID_GRAPHICS_PPV_ARGS(m_fence.ReleaseAndGetAddressOf())));
 
     D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_DISABLE_GPU_TIMEOUT;
     queueDesc.Type = commandListType;
     THROW_IF_FAILED(m_d3d->CreateCommandQueue(
         &queueDesc, 

--- a/DxDispatch/src/dxdispatch/Device.h
+++ b/DxDispatch/src/dxdispatch/Device.h
@@ -24,7 +24,7 @@ public:
     ~Device();
 
     D3d12Module* D3DModule() { return m_d3dModule.get(); }
-    ID3D12Device2* D3D() { return m_d3d.Get(); }
+    ID3D12Device9* D3D() { return m_d3d.Get(); }
     IDMLDevice1* DML() { return m_dml.Get(); }
     ID3D12CommandQueue* GetCommandQueue() { return m_queue.Get(); }
     ID3D12QueryHeap* GetTimestampHeap() { return m_timestampHeap.Get(); }

--- a/DxDispatch/src/dxdispatch/Device.h
+++ b/DxDispatch/src/dxdispatch/Device.h
@@ -16,6 +16,7 @@ public:
         uint32_t dispatchRepeat,
         bool uavBarrierAfterDispatch,
         bool aliasingBarrierAfterDispatch,
+        uint32_t maxGpuTimeMeasurements,
         std::shared_ptr<PixCaptureHelper> pixCaptureHelper,
         std::shared_ptr<D3d12Module> d3dModule,
         std::shared_ptr<DmlModule> dmlModule,
@@ -85,6 +86,8 @@ public:
     // Calls ResolveTimestamps() and converts timestamp pairs into timing samples.
     std::vector<double> ResolveTimingSamples();
 
+    bool GpuTimingEnabled() const { return m_timestampCapacity > 0; }
+
     void KeepAliveUntilNextCommandListDispatch(Microsoft::WRL::ComPtr<IGraphicsUnknown>&& object)
     {
         m_temporaryResources.emplace_back(std::move(object));
@@ -98,9 +101,6 @@ public:
 
     static uint32_t GetSizeInBytes(DML_TENSOR_DATA_TYPE dataType);
     static DXGI_FORMAT GetDxgiFormatFromDmlTensorDataType(DML_TENSOR_DATA_TYPE dataType);
-
-    // Max number of timestamps that may be saved in GPU memory. 
-    static constexpr uint32_t timestampCapacity = 16384;
 
 private:
     void EnsureDxcInterfaces();
@@ -117,6 +117,7 @@ private:
     Microsoft::WRL::ComPtr<IDMLCommandRecorder> m_commandRecorder;
     Microsoft::WRL::ComPtr<ID3D12CommandQueue> m_queue;
     Microsoft::WRL::ComPtr<ID3D12QueryHeap> m_timestampHeap;
+    uint32_t m_timestampCapacity = 0;
     uint32_t m_timestampHeadIndex = 0;
     uint32_t m_timestampCount = 0;
     Microsoft::WRL::ComPtr<ID3D12Fence> m_fence;

--- a/DxDispatch/src/dxdispatch/Device.h
+++ b/DxDispatch/src/dxdispatch/Device.h
@@ -16,6 +16,10 @@ public:
         uint32_t dispatchRepeat,
         bool uavBarrierAfterDispatch,
         bool aliasingBarrierAfterDispatch,
+        bool clearShaderCaches,
+        bool disableGpuTimeout,
+        bool disableBackgroundProcessing,
+        bool setStablePowerState,
         uint32_t maxGpuTimeMeasurements,
         std::shared_ptr<PixCaptureHelper> pixCaptureHelper,
         std::shared_ptr<D3d12Module> d3dModule,
@@ -129,6 +133,8 @@ private:
     std::vector<D3D12_RESOURCE_BARRIER> m_postDispatchBarriers;
     DWORD m_callbackCookie = 0;
     Microsoft::WRL::ComPtr<IDxDispatchLogger> m_logger;
+    bool m_restoreBackgroundProcessing = false;
+    bool m_restoreStablePowerState = false;
 
 #ifndef DXCOMPILER_NONE
     Microsoft::WRL::ComPtr<IDxcUtils> m_dxcUtils;

--- a/DxDispatch/src/dxdispatch/Dispatchable.h
+++ b/DxDispatch/src/dxdispatch/Dispatchable.h
@@ -35,20 +35,5 @@ struct Dispatchable
 
     virtual void Initialize() = 0;
     virtual void Bind(const Bindings& bindings, uint32_t iteration) = 0;
-    virtual void Dispatch(const Model::DispatchCommand& args, uint32_t iteration) = 0;
-
-    virtual bool SupportsDeferredBinding(){ return false; }
-
-    virtual void Wait()
-    {
-        // Only one Wait needs to be implemented, depending on SupportsDeferredBinding()
-        THROW_HR(E_NOTIMPL);
-    }
-
-    virtual void Wait(DeferredBindings& deferredBinings)
-    {
-        // Only one Wait needs to be implemented, depending on SupportsDeferredBinding()
-        THROW_HR(E_NOTIMPL);
-    }
-
+    virtual void Dispatch(const Model::DispatchCommand& args, uint32_t iteration, DeferredBindings& deferredBinings) = 0;
 };

--- a/DxDispatch/src/dxdispatch/DmlDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/DmlDispatchable.cpp
@@ -241,12 +241,8 @@ void DmlDispatchable::Bind(const Bindings& bindings, uint32_t iteration)
     THROW_IF_FAILED(m_device->DML()->GetDeviceRemovedReason());
 }
 
-void DmlDispatchable::Dispatch(const Model::DispatchCommand& args, uint32_t iteration)
+void DmlDispatchable::Dispatch(const Model::DispatchCommand& args, uint32_t iteration, DeferredBindings& deferredBinings)
 {
     m_device->RecordDispatch(m_operatorCompiled.Get(), m_bindingTable.Get());
-}
-
-void DmlDispatchable::Wait()
-{
     m_device->ExecuteCommandListAndWait();
 }

--- a/DxDispatch/src/dxdispatch/DmlDispatchable.h
+++ b/DxDispatch/src/dxdispatch/DmlDispatchable.h
@@ -11,8 +11,7 @@ public:
 
     void Initialize() final;
     void Bind(const Bindings& bindings, uint32_t iteration) final;
-    void Dispatch(const Model::DispatchCommand& args, uint32_t iteration) final;
-    void Wait() final;
+    void Dispatch(const Model::DispatchCommand& args, uint32_t iteration, DeferredBindings& deferredBinings) final;
 
 private:
     std::string m_name;

--- a/DxDispatch/src/dxdispatch/Executor.cpp
+++ b/DxDispatch/src/dxdispatch/Executor.cpp
@@ -370,21 +370,33 @@ void Executor::operator()(const Model::DispatchCommand& command)
                 command.dispatchableName, iterationsCompleted
             ).c_str());
 
-            m_logger->LogInfo(fmt::format("CPU Timings (Cold) : {} samples, {:.4f} ms average, {:.4f} ms min, {:.4f} ms median, {:.4f} ms max",
-                cpuStats.cold.count, cpuStats.cold.average, cpuStats.cold.min, cpuStats.cold.median, cpuStats.cold.max
-            ).c_str());
+            if (cpuStats.cold.count > 0)
+            {
+                m_logger->LogInfo(fmt::format("CPU Timings (Cold) : {} samples, {:.4f} ms average, {:.4f} ms min, {:.4f} ms median, {:.4f} ms max",
+                    cpuStats.cold.count, cpuStats.cold.average, cpuStats.cold.min, cpuStats.cold.median, cpuStats.cold.max
+                ).c_str());
+            }
 
-            m_logger->LogInfo(fmt::format("GPU Timings (Cold) : {} samples, {:.4f} ms average, {:.4f} ms min, {:.4f} ms median, {:.4f} ms max",
-                gpuStats.cold.count, gpuStats.cold.average, gpuStats.cold.min, gpuStats.cold.median, gpuStats.cold.max
-            ).c_str());
+            if (gpuStats.cold.count > 0)
+            {
+                m_logger->LogInfo(fmt::format("GPU Timings (Cold) : {} samples, {:.4f} ms average, {:.4f} ms min, {:.4f} ms median, {:.4f} ms max",
+                    gpuStats.cold.count, gpuStats.cold.average, gpuStats.cold.min, gpuStats.cold.median, gpuStats.cold.max
+                ).c_str());
+            }
 
-            m_logger->LogInfo(fmt::format("CPU Timings (Hot)  : {} samples, {:.4f} ms average, {:.4f} ms min, {:.4f} ms median, {:.4f} ms max",
-                cpuStats.hot.count, cpuStats.hot.average, cpuStats.hot.min, cpuStats.hot.median, cpuStats.hot.max
-            ).c_str());
+            if (cpuStats.hot.count > 0)
+            {
+                m_logger->LogInfo(fmt::format("CPU Timings (Hot)  : {} samples, {:.4f} ms average, {:.4f} ms min, {:.4f} ms median, {:.4f} ms max",
+                    cpuStats.hot.count, cpuStats.hot.average, cpuStats.hot.min, cpuStats.hot.median, cpuStats.hot.max
+                ).c_str());
+            }
 
-            m_logger->LogInfo(fmt::format("GPU Timings (Hot)  : {} samples, {:.4f} ms average, {:.4f} ms min, {:.4f} ms median, {:.4f} ms max",
-                gpuStats.hot.count, gpuStats.hot.average, gpuStats.hot.min, gpuStats.hot.median, gpuStats.hot.max
-            ).c_str());
+            if (gpuStats.hot.count > 0)
+            {
+                m_logger->LogInfo(fmt::format("GPU Timings (Hot)  : {} samples, {:.4f} ms average, {:.4f} ms min, {:.4f} ms median, {:.4f} ms max",
+                    gpuStats.hot.count, gpuStats.hot.average, gpuStats.hot.min, gpuStats.hot.median, gpuStats.hot.max
+                ).c_str());
+            }
 
             if (gpuSamplesOverwritten > 0)
             {

--- a/DxDispatch/src/dxdispatch/HlslDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/HlslDispatchable.cpp
@@ -465,12 +465,8 @@ void HlslDispatchable::Bind(const Bindings& bindings, uint32_t iteration)
     m_device->GetCommandList()->SetComputeRootDescriptorTable(0, m_descriptorHeap->GetGPUDescriptorHandleForHeapStart());
 }
 
-void HlslDispatchable::Dispatch(const Model::DispatchCommand& args, uint32_t iteration)
+void HlslDispatchable::Dispatch(const Model::DispatchCommand& args, uint32_t iteration, DeferredBindings& deferredBinings)
 {
     m_device->RecordDispatch(args.dispatchableName.c_str(), args.threadGroupCount[0], args.threadGroupCount[1], args.threadGroupCount[2]);
-}
-
-void HlslDispatchable::Wait()
-{
     m_device->ExecuteCommandListAndWait();
 }

--- a/DxDispatch/src/dxdispatch/HlslDispatchable.h
+++ b/DxDispatch/src/dxdispatch/HlslDispatchable.h
@@ -9,8 +9,7 @@ public:
 
     void Initialize() final;
     void Bind(const Bindings& bindings, uint32_t iteration) final;
-    void Dispatch(const Model::DispatchCommand& args, uint32_t iteration) final;
-    void Wait() final;
+    void Dispatch(const Model::DispatchCommand& args, uint32_t iteration, DeferredBindings& deferredBinings) final;
 
     enum class BufferViewType
     {

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.h
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.h
@@ -15,9 +15,7 @@ public:
 
     void Initialize() final;
     void Bind(const Bindings& bindings, uint32_t iteration) final;
-    void Dispatch(const Model::DispatchCommand& args, uint32_t iteration) final;
-    bool SupportsDeferredBinding() final { return true; }
-    void Wait(DeferredBindings& defferedBindings) final;
+    void Dispatch(const Model::DispatchCommand& args, uint32_t iteration, DeferredBindings& defferedBindings) final;
 
 private:
     std::shared_ptr<Device> m_device;

--- a/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
+++ b/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
@@ -169,6 +169,10 @@ HRESULT DxDispatch::RuntimeClassInitialize(
                 m_options->DispatchRepeat(),
                 m_options->GetUavBarrierAfterDispatch(),
                 m_options->GetAliasingBarrierAfterDispatch(),
+                m_options->ClearShaderCaches(),
+                m_options->DisableGpuTimeout(),
+                m_options->DisableBackgroundProcessing(),
+                m_options->SetStablePowerState(),
                 m_options->MaxGpuTimeMeasurements(),
                 m_pixCaptureHelper,
                 m_d3dModule,
@@ -183,46 +187,6 @@ HRESULT DxDispatch::RuntimeClassInitialize(
     }
 
     m_logger->LogInfo(fmt::format("Running on '{}'", dxDispatchAdapter->GetDescription()).c_str());
-
-    if (m_options->ClearShaderCaches())
-    {
-        m_device->ClearShaderCaches();
-    }
-
-    if (m_options->DisableBackgroundProcessing())
-    {
-        HRESULT hr = m_device->D3D()->SetBackgroundProcessingMode(
-            D3D12_BACKGROUND_PROCESSING_MODE_DISABLE_BACKGROUND_WORK,
-            D3D12_MEASUREMENTS_ACTION_KEEP_ALL,
-            nullptr,
-            nullptr
-        );
-
-        if (FAILED(hr))
-        {
-            m_logger->LogError("Failed to disable background processing. Do you have developer mode enabled?");
-            return hr;
-        }
-        else
-        {
-            m_logger->LogInfo("Background processing DISABLED");
-        }
-    }
-
-    if (m_options->SetStablePowerState())
-    {
-        // TODO: smart object to unset state
-        HRESULT hr = m_device->D3D()->SetStablePowerState(TRUE);
-        if (FAILED(hr))
-        {
-            m_logger->LogError("Failed to set stable power state. Do you have developer mode enabled?");
-            return hr;
-        }
-        else
-        {
-            m_logger->LogInfo("Stable power state ENABLED");
-        }
-    }
 
     auto inputPath = m_options->InputPath();
     auto outputPath = m_options->OutputPath();

--- a/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
+++ b/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
@@ -169,6 +169,7 @@ HRESULT DxDispatch::RuntimeClassInitialize(
                 m_options->DispatchRepeat(),
                 m_options->GetUavBarrierAfterDispatch(),
                 m_options->GetAliasingBarrierAfterDispatch(),
+                m_options->MaxGpuTimeMeasurements(),
                 m_pixCaptureHelper,
                 m_d3dModule,
                 m_dmlModule,

--- a/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
+++ b/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
@@ -190,20 +190,37 @@ HRESULT DxDispatch::RuntimeClassInitialize(
 
     if (m_options->DisableBackgroundProcessing())
     {
-        THROW_IF_FAILED(m_device->D3D()->SetBackgroundProcessingMode(
+        HRESULT hr = m_device->D3D()->SetBackgroundProcessingMode(
             D3D12_BACKGROUND_PROCESSING_MODE_DISABLE_BACKGROUND_WORK,
             D3D12_MEASUREMENTS_ACTION_KEEP_ALL,
             nullptr,
             nullptr
-        ));
-        m_logger->LogInfo("Background processing disabled");
+        );
+
+        if (FAILED(hr))
+        {
+            m_logger->LogError("Failed to disable background processing. Do you have developer mode enabled?");
+            return hr;
+        }
+        else
+        {
+            m_logger->LogInfo("Background processing DISABLED");
+        }
     }
 
     if (m_options->SetStablePowerState())
     {
         // TODO: smart object to unset state
-        THROW_IF_FAILED(m_device->D3D()->SetStablePowerState(TRUE));
-        m_logger->LogInfo("Stable power state enabled");
+        HRESULT hr = m_device->D3D()->SetStablePowerState(TRUE);
+        if (FAILED(hr))
+        {
+            m_logger->LogError("Failed to set stable power state. Do you have developer mode enabled?");
+            return hr;
+        }
+        else
+        {
+            m_logger->LogInfo("Stable power state ENABLED");
+        }
     }
 
     auto inputPath = m_options->InputPath();

--- a/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
+++ b/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
@@ -188,6 +188,24 @@ HRESULT DxDispatch::RuntimeClassInitialize(
         m_device->ClearShaderCaches();
     }
 
+    if (m_options->DisableBackgroundProcessing())
+    {
+        THROW_IF_FAILED(m_device->D3D()->SetBackgroundProcessingMode(
+            D3D12_BACKGROUND_PROCESSING_MODE_DISABLE_BACKGROUND_WORK,
+            D3D12_MEASUREMENTS_ACTION_KEEP_ALL,
+            nullptr,
+            nullptr
+        ));
+        m_logger->LogInfo("Background processing disabled");
+    }
+
+    if (m_options->SetStablePowerState())
+    {
+        // TODO: smart object to unset state
+        THROW_IF_FAILED(m_device->D3D()->SetStablePowerState(TRUE));
+        m_logger->LogInfo("Stable power state enabled");
+    }
+
     auto inputPath = m_options->InputPath();
     auto outputPath = m_options->OutputPath();
 


### PR DESCRIPTION
This change adds a few features/fixes for profiling (mainly ONNX models). This merges a few private commits from @jeffbloo (thanks Jeff!).
- Option to change size of the GPU timestamp buffer (or disable GPU timing entirely)
- Option to set stable power state & disable background processing in the UMD
- TDR is disabled in the command queue
- Fix a slow memory leak in the DxDispatch command allocator (only applies to ONNX models when GPU timestamps are used; the command allocator wasn't being reset)