### PR TITLE
Update samples and release notes for DML 1.13

### DIFF
--- a/DxDispatch/CMakeLists.txt
+++ b/DxDispatch/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
-project(dxdispatch VERSION 0.16.3 LANGUAGES CXX)
+project(dxdispatch VERSION 0.16.4 LANGUAGES CXX)
 
 # ==============================================================================
 # External Libraries/Helpers

--- a/DxDispatch/cgmanifest.json
+++ b/DxDispatch/cgmanifest.json
@@ -24,7 +24,7 @@
         "type": "nuget",
         "nuget": {
           "name": "Microsoft.AI.DirectML",
-          "version": "1.12.1"
+          "version": "1.13.0"
         }
       }
     },

--- a/DxDispatch/cmake/directml.cmake
+++ b/DxDispatch/cmake/directml.cmake
@@ -48,13 +48,13 @@ function(init_directml_cache_variables prefix)
 
     # <PREFIX>_DIRECTML_NUGET_VERSION
     set(${prefix}_DIRECTML_NUGET_VERSION
-        1.12.1
+        1.13.0
         CACHE STRING "Version of the DirectML NuGet package (TYPE == nuget)."
     )
 
     # <PREFIX>_DIRECTML_NUGET_HASH
     set(${prefix}_DIRECTML_NUGET_HASH 
-        814b628d826be37b244dddb55665bcdf68704db815ece9329452adb211946af6
+        554ab59a2abecc5251e4725231c774b42d1c4a0a5bad0f683d4dbcafa78ed318
         CACHE STRING "SHA256 hash of the DirectML NuGet package (TYPE == nuget)."
     )
 

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -2148,12 +2148,10 @@ namespace dml
 
         TensorDesc inputTensor = input.Impl()->GetOutputDesc();
         const uint32_t defaultStridesAndDilations[3] = { 1, 1, 1 };
-        uint32_t dimensionCount = static_cast<uint32_t>(inputTensor.sizes.size());
-        uint32_t spatialDimensionCount = dimensionCount - 2;
 
 #if DML_TARGET_VERSION >= 0x6200
         DML_AVERAGE_POOLING1_OPERATOR_DESC averagePoolDesc = {};
-        assert(dilations.empty() || dilations.size() == spatialDimensionCount);
+        assert(dilations.empty() || dilations.size() == inputTensor.sizes.size() - 2);
         averagePoolDesc.Dilations = dilations.empty() ? defaultStridesAndDilations : dilations.data();
 #else
         DML_AVERAGE_POOLING_OPERATOR_DESC averagePoolDesc = {};
@@ -3324,7 +3322,7 @@ namespace dml
         TensorDimensions outputSizes,
         DML_INTERPOLATION_MODE mode,
 #if DML_TARGET_VERSION >= 0x5100
-        DML_AXIS_DIRECTION roundingDirection,
+        DML_AXIS_DIRECTION roundingDirection = DML_AXIS_DIRECTION_INCREASING,
 #endif // DML_TARGET_VERSION >= 0x5100
         Span<const float> scales = {},
         Span<const float> inputPixelOffsets = {},

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -2152,6 +2152,7 @@ namespace dml
         const uint32_t defaultStridesAndDilations[3] = { 1, 1, 1 };
 
         DML_AVERAGE_POOLING1_OPERATOR_DESC averagePoolDesc = {};
+        // dilations must be omitted or have the same rank as the spatial dimension count (inputTensor rank - 2)
         assert(dilations.empty() || dilations.size() == inputTensor.sizes.size() - 2);
         averagePoolDesc.Dilations = dilations.empty() ? defaultStridesAndDilations : dilations.data();
 #else

--- a/Releases.md
+++ b/Releases.md
@@ -4,6 +4,7 @@ See [DirectML version history on MSDN](https://docs.microsoft.com/windows/win32/
 
 | Version                  | Feature level                                                                                                            | First available in OS                                             | Redistributable                                                                             |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [1.13.0](#directml-1130) | [DML_FEATURE_LEVEL_6_2](https://learn.microsoft.com/windows/ai/directml/dml-feature-level-history#dml_feature_level_6_2) | TBD                                                               | [Microsoft.AI.DirectML.1.13.0](https://www.nuget.org/packages/Microsoft.AI.DirectML/1.13.0) |
 | [1.12.1](#directml-1121) | [DML_FEATURE_LEVEL_6_1](https://learn.microsoft.com/windows/ai/directml/dml-feature-level-history#dml_feature_level_6_1) | TBD                                                               | [Microsoft.AI.DirectML.1.12.1](https://www.nuget.org/packages/Microsoft.AI.DirectML/1.12.1) |
 | [1.12.0](#directml-1120) | [DML_FEATURE_LEVEL_6_1](https://learn.microsoft.com/windows/ai/directml/dml-feature-level-history#dml_feature_level_6_1) | TBD                                                               | [Microsoft.AI.DirectML.1.12.0](https://www.nuget.org/packages/Microsoft.AI.DirectML/1.12.0) |
 | [1.11.0](#directml-1110) | [DML_FEATURE_LEVEL_6_0](https://learn.microsoft.com/windows/ai/directml/dml-feature-level-history#dml_feature_level_6_0) | TBD                                                               | [Microsoft.AI.DirectML.1.11.0](https://www.nuget.org/packages/Microsoft.AI.DirectML/1.11.0) |
@@ -24,6 +25,32 @@ See [DirectML version history on MSDN](https://docs.microsoft.com/windows/win32/
 | [1.4.0](#directml-140)   | [DML_FEATURE_LEVEL_3_0](https://learn.microsoft.com/windows/ai/directml/dml-feature-level-history#dml_feature_level_3_0) | Redistributable only                                              | [Microsoft.AI.DirectML.1.4.0](https://www.nuget.org/packages/Microsoft.AI.DirectML/1.4.0)   |
 | [1.1.0](#directml-110)   | [DML_FEATURE_LEVEL_2_0](https://learn.microsoft.com/windows/ai/directml/dml-feature-level-history#dml_feature_level_2_0) | Windows 10 May 2020 Update, Version 2004 (Build 10.0.19041, 20H1) | -                                                                                           |
 | [1.0.0](#directml-100)   | [DML_FEATURE_LEVEL_1_0](https://learn.microsoft.com/windows/ai/directml/dml-feature-level-history#dml_feature_level_1_0) | Windows 10 May 2019 Update, Version 1903 (Build 10.0.18362; 19H1) | -                                                                                           |
+
+# DirectML 1.13.0
+
+-	Enabled Intel Core Ultra NPU support with performance focused on select deep learning models. 
+- Introduced DML_FEATURE_LEVEL 6.2:
+  -	Added 6 new operators:
+    -	DML_OPERATOR_LP_POOLING1
+    -	DML_OPERATOR_AVERAGE_POOLING1
+    -	DML_OPERATOR_ACTIVATION_SWISH
+    -	DML_OPERATOR_ACTIVATION_HARD_SWISH
+    -	DML_OPERATOR_QUANTIZED_LINEAR_AVERAGE_POOLING
+    -	DML_OPERATOR_MATRIX_MULTIPLY_INTEGER_TO_FLOAT
+-	Made ZeroPointTensor optional for DML_OPERATOR_ELEMENT_WISE_QUANTIZE_LINEAR and DML_OPERATOR_ELEMENT_WISE_DEQUANTIZE_LINEAR.
+-	Added a new graph node type DML_GRAPH_NODE_TYPE_CONSTANT to enable compile-time optimizations that require content of small tensors.
+-	Fixed bug in DML_OPERATOR_LSTM when used with reduction-based activation function like DML_OPERATOR_ACTIVATION_HARDMAX. 
+-	Fixed bug in DML_OPERATOR_GEMM when there is additional padding and channel axis is a multiple of 16 bytes.
+-	Added UINT8/INT8 data type support for DML_OPERATOR_RESAMPLE2.
+-	Added ARM64EC variant for DirectML redistributable package in NuGet.
+- Updated Xbox Series X/S binaries to support the 230307, 230603, and 231000 GDK editions.
+- Bug fixes.
+
+**Known Issue**: models containing Join operations may exhibit a slight performance regression relative to 1.12.1, particularly if the model is low-precision or memory-bandwidth limited. This issue will be fixed in the 1.13.1 release.
+
+# DirectML 1.12.1
+
+- Fixed bug in compiled graphs with elided cast nodes that could result in some models producing invalid output values ([issue](https://github.com/microsoft/DirectML/issues/483)).
 
 # DirectML 1.12.0
 
@@ -60,6 +87,7 @@ See [DirectML version history on MSDN](https://docs.microsoft.com/windows/win32/
 - Fixed DML_OPERATOR_ELEMENT_WISE_MODULUS_TRUNCATE/FLOOR precision issue with non-power of 2 on specific GPUs.
 - Fixed DML_OPERATOR_CAST casting between 16-bit and 64-bit data types on specific GPUs.
 - Fixed DML_OPERATOR_ACTIVATION_HARDMAX/1 result for certain OutputTensor stride.
+- Added Xbox Series X/S binaries to support the 220301, 220604, and 221000 GDK editions.
 
 # DirectML 1.9.1
 

--- a/Releases.md
+++ b/Releases.md
@@ -28,21 +28,21 @@ See [DirectML version history on MSDN](https://docs.microsoft.com/windows/win32/
 
 # DirectML 1.13.0
 
--	Enabled Intel Core Ultra NPU support with performance focused on select deep learning models. 
+- Enabled Intel Core Ultra NPU support with performance focused on select deep learning models. 
 - Introduced DML_FEATURE_LEVEL 6.2:
-  -	Added 6 new operators:
-    -	DML_OPERATOR_LP_POOLING1
-    -	DML_OPERATOR_AVERAGE_POOLING1
-    -	DML_OPERATOR_ACTIVATION_SWISH
-    -	DML_OPERATOR_ACTIVATION_HARD_SWISH
-    -	DML_OPERATOR_QUANTIZED_LINEAR_AVERAGE_POOLING
-    -	DML_OPERATOR_MATRIX_MULTIPLY_INTEGER_TO_FLOAT
--	Made ZeroPointTensor optional for DML_OPERATOR_ELEMENT_WISE_QUANTIZE_LINEAR and DML_OPERATOR_ELEMENT_WISE_DEQUANTIZE_LINEAR.
--	Added a new graph node type DML_GRAPH_NODE_TYPE_CONSTANT to enable compile-time optimizations that require content of small tensors.
--	Fixed bug in DML_OPERATOR_LSTM when used with reduction-based activation function like DML_OPERATOR_ACTIVATION_HARDMAX. 
--	Fixed bug in DML_OPERATOR_GEMM when there is additional padding and channel axis is a multiple of 16 bytes.
--	Added UINT8/INT8 data type support for DML_OPERATOR_RESAMPLE2.
--	Added ARM64EC variant for DirectML redistributable package in NuGet.
+  - Added 6 new operators:
+    - DML_OPERATOR_LP_POOLING1
+    - DML_OPERATOR_AVERAGE_POOLING1
+    - DML_OPERATOR_ACTIVATION_SWISH
+    - DML_OPERATOR_ACTIVATION_HARD_SWISH
+    - DML_OPERATOR_QUANTIZED_LINEAR_AVERAGE_POOLING
+    - DML_OPERATOR_MATRIX_MULTIPLY_INTEGER_TO_FLOAT
+- Made ZeroPointTensor optional for DML_OPERATOR_ELEMENT_WISE_QUANTIZE_LINEAR and DML_OPERATOR_ELEMENT_WISE_DEQUANTIZE_LINEAR.
+- Added a new graph node type DML_GRAPH_NODE_TYPE_CONSTANT to enable compile-time optimizations that require content of small tensors.
+- Fixed bug in DML_OPERATOR_LSTM when used with reduction-based activation function like DML_OPERATOR_ACTIVATION_HARDMAX. 
+- Fixed bug in DML_OPERATOR_GEMM when there is additional padding and channel axis is a multiple of 16 bytes.
+- Added UINT8/INT8 data type support for DML_OPERATOR_RESAMPLE2.
+- Added ARM64EC variant for DirectML redistributable package in NuGet.
 - Updated Xbox Series X/S binaries to support the 230307, 230603, and 231000 GDK editions.
 - Bug fixes.
 

--- a/Samples/DirectMLSuperResolution/DirectMLSuperResolution.vcxproj
+++ b/Samples/DirectMLSuperResolution/DirectMLSuperResolution.vcxproj
@@ -40,58 +40,58 @@
     <ProjectGuid>{70CDBD87-F286-4EE0-87F1-5A1D09396CDA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>DirectMLSuperResolution</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Samples/DirectMLSuperResolution/DirectMLSuperResolution.vcxproj
+++ b/Samples/DirectMLSuperResolution/DirectMLSuperResolution.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props')" />
+  <Import Project="packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -560,14 +560,14 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets" Condition="Exists('packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets')" />
-    <Import Project="packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets')" />
+    <Import Project="packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets'))" />
   </Target>
 </Project>

--- a/Samples/DirectMLSuperResolution/DirectMLXSuperResolution.vcxproj
+++ b/Samples/DirectMLSuperResolution/DirectMLXSuperResolution.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props')" />
+  <Import Project="packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -562,14 +562,14 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets" Condition="Exists('packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets')" />
-    <Import Project="packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets')" />
+    <Import Project="packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets'))" />
   </Target>
 </Project>

--- a/Samples/DirectMLSuperResolution/DirectMLXSuperResolution.vcxproj
+++ b/Samples/DirectMLSuperResolution/DirectMLXSuperResolution.vcxproj
@@ -40,58 +40,58 @@
     <ProjectGuid>{31C25314-96AE-4EF0-84B7-0026C14F12AD}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>DirectMLXSuperResolution</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Samples/DirectMLSuperResolution/Kits/DirectXTK12/DirectXTK_Desktop_2017_Win10.vcxproj
+++ b/Samples/DirectMLSuperResolution/Kits/DirectXTK12/DirectXTK_Desktop_2017_Win10.vcxproj
@@ -471,55 +471,55 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectName>DirectXTK12</ProjectName>
     <RootNamespace>DirectXTK12</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Samples/DirectMLSuperResolution/packages.config
+++ b/Samples/DirectMLSuperResolution/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AI.DirectML" version="1.12.1" targetFramework="native" />
+  <package id="Microsoft.AI.DirectML" version="1.13.0" targetFramework="native" />
   <package id="WinPixEventRuntime" version="1.0.210209001" targetFramework="native" />
 </packages>

--- a/Samples/HelloDirectML/HelloDirectML.vcxproj
+++ b/Samples/HelloDirectML/HelloDirectML.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props')" />
+  <Import Project="packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -436,14 +436,14 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-    <Import Project="packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets')" />
+    <Import Project="packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets'))" />
   </Target>
 </Project>

--- a/Samples/HelloDirectML/HelloDirectMLX.vcxproj
+++ b/Samples/HelloDirectML/HelloDirectMLX.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props')" />
+  <Import Project="packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -436,14 +436,14 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-    <Import Project="packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets')" />
+    <Import Project="packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets'))" />
   </Target>
 </Project>

--- a/Samples/HelloDirectML/main.cpp
+++ b/Samples/HelloDirectML/main.cpp
@@ -366,7 +366,7 @@ int main()
         nullptr,
         IID_GRAPHICS_PPV_ARGS(inputBuffer.GetAddressOf())));
 
-    std::wcout << std::fixed; std::wcout.precision(2);
+    std::wcout << std::fixed; std::wcout.precision(4);
     std::array<FLOAT, tensorElementCount> inputTensorElementArray;
     {
         std::wcout << L"input tensor: ";

--- a/Samples/HelloDirectML/packages.config
+++ b/Samples/HelloDirectML/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AI.DirectML" version="1.12.1" targetFramework="native" />
+  <package id="Microsoft.AI.DirectML" version="1.13.0" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
 </packages>

--- a/Samples/yolov4/Kits/DirectXTK12/DirectXTK_Desktop_2017_Win10.vcxproj
+++ b/Samples/yolov4/Kits/DirectXTK12/DirectXTK_Desktop_2017_Win10.vcxproj
@@ -471,55 +471,55 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectName>DirectXTK12</ProjectName>
     <RootNamespace>DirectXTK12</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Samples/yolov4/packages.config
+++ b/Samples/yolov4/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AI.DirectML" version="1.12.1" targetFramework="native" />
+  <package id="Microsoft.AI.DirectML" version="1.13.0" targetFramework="native" />
   <package id="WinPixEventRuntime" version="1.0.210209001" targetFramework="native" />
 </packages>

--- a/Samples/yolov4/yolov4.vcxproj
+++ b/Samples/yolov4/yolov4.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props')" />
+  <Import Project="packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props" Condition="Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -566,7 +566,7 @@ copy $(ProjectDir)data\. $(OutDir)data</Command>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets" Condition="Exists('packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets')" />
-    <Import Project="packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets')" />
+    <Import Project="packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets')" />
   </ImportGroup>
   <Target Name="DownloadContentFiles" BeforeTargets="PrepareForBuild" Condition="!Exists('Data\yolov4.weights')">
     <DownloadFile SourceUrl="https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v3_optimal/yolov4.weights" DestinationFolder="$(MSBuildProjectDirectory)\Data">
@@ -578,7 +578,7 @@ copy $(ProjectDir)data\. $(OutDir)data</Command>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\WinPixEventRuntime.1.0.210209001\build\WinPixEventRuntime.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.12.1\build\Microsoft.AI.DirectML.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.AI.DirectML.1.13.0\build\Microsoft.AI.DirectML.targets'))" />
   </Target>
 </Project>

--- a/Samples/yolov4/yolov4.vcxproj
+++ b/Samples/yolov4/yolov4.vcxproj
@@ -40,58 +40,58 @@
     <ProjectGuid>{70CDBD87-F286-4EE0-87F1-5A1D09396CDA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>yolov4</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
- Release notes for the DML 1.13.0.
- Updates our C++ samples and DxDispatch to use the latest DML 1.13.0 redistributable package.
- Fix a few warnings in DirectMLX.h (treated as errors in C++ samples).
- Update samples to a newer MSVC toolset (VS2022).
