### PR TITLE
Update Code to work with agility SDK, added Dred, update agilitySdk

### DIFF
--- a/DxDispatch/CMakeLists.txt
+++ b/DxDispatch/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
-project(dxdispatch VERSION 0.16.4 LANGUAGES CXX)
+project(dxdispatch VERSION 0.16.5 LANGUAGES CXX)
 
 # ==============================================================================
 # External Libraries/Helpers

--- a/DxDispatch/cgmanifest.json
+++ b/DxDispatch/cgmanifest.json
@@ -15,7 +15,7 @@
         "type": "nuget",
         "nuget": {
           "name": "Microsoft.Direct3D.D3D12",
-          "version": "1.610.2"
+          "version": "1.611.2"
         }
       }
     },

--- a/DxDispatch/cmake/d3d12.cmake
+++ b/DxDispatch/cmake/d3d12.cmake
@@ -57,13 +57,13 @@ function(init_d3d12_cache_variables prefix)
 
     # <PREFIX>_D3D12_NUGET_VERSION
     set(${prefix}_D3D12_NUGET_VERSION
-        1.610.2
+        1.611.2
         CACHE STRING "Version of the D3D12 NuGet package (TYPE == nuget)."
     )
 
     # <PREFIX>_D3D12_NUGET_HASH
     set(${prefix}_D3D12_NUGET_HASH 
-        62C63EF7579E0A6AF35F9E6C9C5FC78C3B6F056695EC8933D8E1A0DA022CC914
+        414858c5cf25e43022938ab992d78a9639b1a9a48efe5b4a05fca2df9294388c
         CACHE STRING "SHA256 hash of the D3D12 NuGet package (TYPE == nuget)."
     )
 

--- a/DxDispatch/doc/Guide.md
+++ b/DxDispatch/doc/Guide.md
@@ -72,7 +72,7 @@ There are more options available to you. If you run the executable with no argum
 ```
 dxdispatch version 0.15.0
   DirectML     : NuGet (Microsoft.AI.DirectML.1.11.0)
-  D3D12        : NuGet (Microsoft.Direct3D.D3D12.1.610.2)
+  D3D12        : NuGet (Microsoft.Direct3D.D3D12.1.611.2)
   DXCompiler   : Release (v1.7.2212.1)
   PIX          : NuGet (WinPixEventRuntime.1.0.230302001)
   ONNX Runtime : NuGet (Microsoft.ML.OnnxRuntime.DirectML.1.14.1)

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -132,6 +132,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
             cxxopts::value<bool>()
         )
         (
+            "enable_dred", 
+            "Enables SetAutoBreadcrumbsEnablement and SetPageFaultEnablement on the device", 
+            cxxopts::value<bool>()
+        )
+        (
             "disable_background_processing", 
             "Disallows UMD from performing PGO in background threads. Requires developer mode.", 
             cxxopts::value<bool>()
@@ -320,6 +325,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
     if (result.count("disable_gpu_timeout"))
     {
         m_disableGpuTimeout = result["disable_gpu_timeout"].as<bool>();
+    }
+
+    if (result.count("enable_dred"))
+    {
+        m_enableDred = result["enable_dred"].as<bool>();
     }
 
     if (result.count("disable_background_processing"))

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.h
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.h
@@ -25,6 +25,7 @@ public:
     bool ForceDisablePrecompiledShadersOnXbox() const { return m_forceDisablePrecompiledShadersOnXbox; }
     bool ClearShaderCaches() const { return m_clearShaderCaches; }
     bool DisableGpuTimeout() const { return m_disableGpuTimeout; }
+    bool EnableDred() const { return m_enableDred; }
     bool DisableBackgroundProcessing() const { return m_disableBackgroundProcessing; }
     bool SetStablePowerState() const { return m_setStablePowerState; }
     bool DisableAgilitySDK() const { return m_disableAgilitySDK; }
@@ -78,6 +79,7 @@ private:
     bool m_forceDisablePrecompiledShadersOnXbox = true;
     bool m_clearShaderCaches = false;
     bool m_disableGpuTimeout = false;
+    bool m_enableDred = false;
     bool m_disableBackgroundProcessing = false;
     bool m_setStablePowerState = false;
     bool m_disableAgilitySDK = false;

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -106,10 +106,12 @@ Device::Device(
 
     if(enableDred)
     {
+        // Enables more debug info for TDRs, can be used with Debugger 
+        // extension see following link for more info:
+        // https://learn.microsoft.com/en-us/windows/win32/direct3d12/use-dred
         ComPtr<ID3D12DeviceRemovedExtendedDataSettings> pDredSettings;
         if(SUCCEEDED(m_d3dModule->GetDebugInterface(IID_PPV_ARGS(&pDredSettings))))
         {
-            // Turn on AutoBreadcrumbs and Page Fault reportingc:
             pDredSettings->SetAutoBreadcrumbsEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
             pDredSettings->SetPageFaultEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
         }

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -48,6 +48,7 @@ Device::Device(
     bool aliasingBarrierAfterDispatch,
     bool clearShaderCaches,
     bool disableGpuTimeout,
+    bool enableDred,
     bool disableBackgroundProcessing,
     bool setStablePowerState,
     uint32_t maxGpuTimeMeasurements,
@@ -102,6 +103,17 @@ Device::Device(
         adapter, 
         featureLevel, 
         IID_PPV_ARGS(&m_d3d)));
+
+    if(enableDred)
+    {
+        ComPtr<ID3D12DeviceRemovedExtendedDataSettings> pDredSettings;
+        if(SUCCEEDED(m_d3dModule->GetDebugInterface(IID_PPV_ARGS(&pDredSettings))))
+        {
+            // Turn on AutoBreadcrumbs and Page Fault reportingc:
+            pDredSettings->SetAutoBreadcrumbsEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
+            pDredSettings->SetPageFaultEnablement(D3D12_DRED_ENABLEMENT_FORCED_ON);
+        }
+    }
 
     if (debugLayersEnabled)
     {

--- a/DxDispatch/src/dxdispatch/Device.h
+++ b/DxDispatch/src/dxdispatch/Device.h
@@ -18,6 +18,7 @@ public:
         bool aliasingBarrierAfterDispatch,
         bool clearShaderCaches,
         bool disableGpuTimeout,
+        bool enableDred,
         bool disableBackgroundProcessing,
         bool setStablePowerState,
         uint32_t maxGpuTimeMeasurements,

--- a/DxDispatch/src/dxdispatch/DxModules.cpp
+++ b/DxDispatch/src/dxdispatch/DxModules.cpp
@@ -78,16 +78,11 @@ D3d12Module::D3d12Module(bool disableAgilitySDK, const char* moduleName) : Modul
             if(m_d3d12SDKConfiguration)
             {
                 ComPtr<ID3D12SDKConfiguration1> pD3D12SDKConfiguration;
-                HRESULT hr = m_d3d12SDKConfiguration(CLSID_D3D12SDKConfiguration, IID_PPV_ARGS(&pD3D12SDKConfiguration));
+                THROW_IF_FAILED(m_d3d12SDKConfiguration(CLSID_D3D12SDKConfiguration, IID_PPV_ARGS(&pD3D12SDKConfiguration)));
+
                 ComPtr<ID3D12DeviceFactory> deviceFactory;
-                if(SUCCEEDED(hr))
-                {
-                    hr = pD3D12SDKConfiguration->CreateDeviceFactory(D3D12SDKVersion, D3D12SDKPath, IID_PPV_ARGS(&deviceFactory));
-                }
-                if(SUCCEEDED(hr))
-                {
-                    hr = deviceFactory->ApplyToGlobalState();
-                }
+                THROW_IF_FAILED(pD3D12SDKConfiguration->CreateDeviceFactory(D3D12SDKVersion, D3D12SDKPath, IID_PPV_ARGS(&deviceFactory)));
+                THROW_IF_FAILED(deviceFactory->ApplyToGlobalState());
             }
         }
 #endif

--- a/DxDispatch/src/dxdispatch/DxModules.cpp
+++ b/DxDispatch/src/dxdispatch/DxModules.cpp
@@ -4,20 +4,11 @@
 #ifndef WIN32
 #include <dlfcn.h>
 #endif
+using namespace Microsoft::WRL;
 
 #if !defined(_GAMING_XBOX) && defined(WIN32)
 extern "C" { __declspec(dllexport) extern UINT D3D12SDKVersion = DIRECT3D_AGILITY_SDK_VERSION; }
 extern "C" { __declspec(dllexport) extern const char* D3D12SDKPath = u8"./D3D12/"; }
-
-void SetDisableAgilitySDK(bool disableAgilitySDK)
-{
-    if (disableAgilitySDK)
-    {
-        D3D12SDKVersion = 0;
-    }
-}
-#else
-void SetDisableAgilitySDK(bool disableAgilitySDK) { }
 #endif
 
 Module::Module(const char* moduleName)
@@ -76,10 +67,31 @@ void* Module::GetSymbol(const char* name)
 #endif
 }
 
-D3d12Module::D3d12Module(const char* moduleName) : Module(moduleName)
+D3d12Module::D3d12Module(bool disableAgilitySDK, const char* moduleName) : Module(moduleName)
 {
     if (m_module)
     {
+#if !defined(_GAMING_XBOX) && defined(WIN32)
+        if(!disableAgilitySDK)
+        {
+            InitSymbol(&m_d3d12SDKConfiguration, "D3D12GetInterface");
+            if(m_d3d12SDKConfiguration)
+            {
+                ComPtr<ID3D12SDKConfiguration1> pD3D12SDKConfiguration;
+                HRESULT hr = m_d3d12SDKConfiguration(CLSID_D3D12SDKConfiguration, IID_PPV_ARGS(&pD3D12SDKConfiguration));
+                ComPtr<ID3D12DeviceFactory> deviceFactory;
+                if(SUCCEEDED(hr))
+                {
+                    hr = pD3D12SDKConfiguration->CreateDeviceFactory(D3D12SDKVersion, D3D12SDKPath, IID_PPV_ARGS(&deviceFactory));
+                }
+                if(SUCCEEDED(hr))
+                {
+                    hr = deviceFactory->ApplyToGlobalState();
+                }
+            }
+        }
+#endif
+
         InitSymbol(&m_d3d12CreateDevice, "D3D12CreateDevice");
         InitSymbol(&m_d3d12GetDebugInterface, "D3D12GetDebugInterface");
         InitSymbol(&m_d3d12SerializeVersionedRootSignature, "D3D12SerializeVersionedRootSignature");

--- a/DxDispatch/src/dxdispatch/DxModules.h
+++ b/DxDispatch/src/dxdispatch/DxModules.h
@@ -2,9 +2,6 @@
 
 #include "ModuleInfo.h"
 
-// Must be called before D3D12 is loaded.
-void SetDisableAgilitySDK(bool disableAgilitySDK);
-
 class Module
 {
 public:
@@ -53,9 +50,9 @@ class D3d12Module : public Module
 public:
 #if defined(_GAMING_XBOX)
     // Intentionally set to null; D3D12 is dynamically linked for Xbox.
-    D3d12Module(const char* moduleName = nullptr);
+    D3d12Module(bool disableAgilitySDK, const char* moduleName = nullptr);
 #else
-    D3d12Module(const char* moduleName = c_direct3dModuleName);
+    D3d12Module(bool disableAgilitySDK, const char* moduleName = c_direct3dModuleName);
 #endif
 
 #ifndef _GAMING_XBOX
@@ -83,6 +80,7 @@ private:
     decltype(&D3D12CreateDevice) m_d3d12CreateDevice = nullptr;
     decltype(&D3D12GetDebugInterface) m_d3d12GetDebugInterface = nullptr;
     decltype(&D3D12SerializeVersionedRootSignature) m_d3d12SerializeVersionedRootSignature = nullptr;
+    decltype(&D3D12GetInterface) m_d3d12SDKConfiguration = nullptr;
 };
 
 // Wraps dxcore.dll / libdxcore.so. Not used for Xbox.

--- a/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
+++ b/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
@@ -94,6 +94,10 @@ HRESULT DxDispatch::RuntimeClassInitialize(
         m_logger->LogError(fmt::format("Failed to parse command-line arguments: {}", e.what()).c_str());
         throw;
     }
+
+    // Needs to be constructed *before* D3D12 device. A warning is printed if DXCore.dll is loaded first,
+    // even though the D3D12Device isn't created yet, so we create the capture helper first to avoid this
+    // message.
     m_pixCaptureHelper = std::make_shared<PixCaptureHelper>(m_options->GetPixCaptureType(), m_options->PixCaptureName());
     m_d3dModule = std::make_shared<D3d12Module>(m_options->DisableAgilitySDK());
     m_dxCoreModule = std::make_shared<DxCoreModule>();

--- a/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
+++ b/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
@@ -94,16 +94,9 @@ HRESULT DxDispatch::RuntimeClassInitialize(
         m_logger->LogError(fmt::format("Failed to parse command-line arguments: {}", e.what()).c_str());
         throw;
     }
-   
-
-    SetDisableAgilitySDK(m_options->DisableAgilitySDK());
-
-    // Needs to be constructed *before* D3D12 device. A warning is printed if DXCore.dll is loaded first,
-    // even though the D3D12Device isn't created yet, so we create the capture helper first to avoid this
-    // message.
     m_pixCaptureHelper = std::make_shared<PixCaptureHelper>(m_options->GetPixCaptureType(), m_options->PixCaptureName());
+    m_d3dModule = std::make_shared<D3d12Module>(m_options->DisableAgilitySDK());
     m_dxCoreModule = std::make_shared<DxCoreModule>();
-    m_d3dModule = std::make_shared<D3d12Module>();
     m_dmlModule = std::make_shared<DmlModule>();
 
     if (m_options->PrintHelp())
@@ -171,6 +164,7 @@ HRESULT DxDispatch::RuntimeClassInitialize(
                 m_options->GetAliasingBarrierAfterDispatch(),
                 m_options->ClearShaderCaches(),
                 m_options->DisableGpuTimeout(),
+                m_options->EnableDred(),
                 m_options->DisableBackgroundProcessing(),
                 m_options->SetStablePowerState(),
                 m_options->MaxGpuTimeMeasurements(),


### PR DESCRIPTION
1. When code was refactored the old mechanism for setting agility SDK did not work, updated code to do it programmatically 
2. Updated code to better debug TDRs with Dred - can analyze through debugger extension using d3d12!D3D12DeviceRemovedExtendedData (https://learn.microsoft.com/en-us/windows/win32/direct3d12/use-dred)
3. Update Agility SDK for DX12 to latest supported version 