### PR TITLE
Dxdispatch present separator

### DIFF
--- a/DxDispatch/CMakeLists.txt
+++ b/DxDispatch/CMakeLists.txt
@@ -82,6 +82,7 @@ target_link_libraries(
     wil
     d3d12
     directml
+	dxgi
 )
 
 if(TARGET_WSL)
@@ -142,6 +143,9 @@ endif()
 set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT dxdispatch)
 
 if(WIN32)
+    if(TARGET_WINDOWS)
+        target_compile_definitions(dxdispatchImpl PRIVATE DX_PRESENT_SEPARATOR=1)
+    endif()
     target_sources(dxdispatchImpl PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/dxdispatchImpl.rc)
     target_link_libraries(dxdispatchImpl PRIVATE version.lib)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/dxdispatch/dxdispatchImpl.rc.in dxdispatchImpl.rc)

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -177,6 +177,13 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
             "Name used for PIX capture files.",
             cxxopts::value<std::string>()->default_value("dxdispatch")
         )
+#if defined(DX_PRESENT_SEPARATOR)
+        (
+            "present_separator",
+            "Injects present after each full inference pass, giving debugging tools a notion of frames.",
+            cxxopts::value<bool>()
+        )
+#endif
         ;
 
     // ONNX OPTIONS
@@ -336,6 +343,13 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
     {
         m_disableAgilitySDK = result["disable_agility_sdk"].as<bool>();
     }
+
+#if defined(DX_PRESENT_SEPARATOR)
+    if (result.count("present_separator"))
+    {
+        m_presentSeparator = result["present_separator"].as<bool>();
+    }
+#endif
 
     if (result.count("print_hlsl_disassembly"))
     {

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.h
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.h
@@ -51,6 +51,10 @@ public:
     PixCaptureType GetPixCaptureType() const { return m_pixCaptureType; }
     const std::string& PixCaptureName() const { return m_pixCaptureName; }
 
+#if defined(DX_PRESENT_SEPARATOR)
+    bool GetPresentSeparator() const { return m_presentSeparator; }
+#endif
+
     bool GetUavBarrierAfterDispatch() const { return m_uavBarrierAfterDispatch; }
     bool GetAliasingBarrierAfterDispatch() const { return m_aliasingBarrierAfterDispatch; }
     bool  PrintCommands() const { return m_commandPrinting; }
@@ -81,6 +85,9 @@ private:
     bool m_disableBackgroundProcessing = false;
     bool m_setStablePowerState = false;
     bool m_disableAgilitySDK = false;
+#if defined(DX_PRESENT_SEPARATOR)
+    bool m_presentSeparator = false;
+#endif
     bool m_uavBarrierAfterDispatch = true;
     bool m_aliasingBarrierAfterDispatch = false;
     std::string m_adapterSubstring = "";

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -1,6 +1,10 @@
 #include "pch.h"
 #include "Device.h"
 
+#if defined(DX_PRESENT_SEPARATOR)
+#include <dxgi1_6.h>
+#endif
+
 using Microsoft::WRL::ComPtr;
 
 // {0059DA69-B561-43D9-A39B-3355074B1082}
@@ -153,6 +157,29 @@ Device::Device(
         &queueDesc, 
         IID_GRAPHICS_PPV_ARGS(m_queue.ReleaseAndGetAddressOf())));
     m_commandListType = queueDesc.Type;
+
+#if defined(DX_PRESENT_SEPARATOR)
+    // Create dummy swapchain for frame indication
+    {
+        ComPtr<IDXGIFactory2> factory;
+        THROW_IF_FAILED(CreateDXGIFactory2(DXGI_CREATE_FACTORY_DEBUG, IID_PPV_ARGS(&factory)));
+        DXGI_SWAP_CHAIN_DESC1 desc = {0};
+        desc.Width = 2;
+        desc.Height = 2;
+        desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+        desc.Stereo = FALSE;
+        desc.SampleDesc.Count = 1;
+        desc.SampleDesc.Quality = 0;
+        desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT | DXGI_USAGE_BACK_BUFFER;
+        desc.BufferCount = 3;
+        desc.Scaling = DXGI_SCALING_STRETCH;
+        desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+        desc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
+        desc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+        const auto HR = factory->CreateSwapChainForComposition(m_queue.Get(), &desc, nullptr, m_dummySwapChain.GetAddressOf());
+        THROW_IF_FAILED(HR);
+    }
+#endif
 
     THROW_IF_FAILED(m_dmlModule->CreateDevice1(
         m_d3d.Get(), 
@@ -639,3 +666,13 @@ void Device::ClearShaderCaches()
     default: throw std::invalid_argument(fmt::format("No DXGI_FORMAT exists for given data type."));
     }
 }
+
+#if defined(DX_PRESENT_SEPARATOR)
+void Device::DummyPreset()
+{
+    if (m_dummySwapChain)
+    {
+        m_dummySwapChain->Present(0, 0);
+    }
+}
+#endif

--- a/DxDispatch/src/dxdispatch/Device.h
+++ b/DxDispatch/src/dxdispatch/Device.h
@@ -106,6 +106,10 @@ public:
     static uint32_t GetSizeInBytes(DML_TENSOR_DATA_TYPE dataType);
     static DXGI_FORMAT GetDxgiFormatFromDmlTensorDataType(DML_TENSOR_DATA_TYPE dataType);
 
+#if defined(DX_PRESENT_SEPARATOR)
+    void DummyPreset();
+#endif
+
 private:
     void EnsureDxcInterfaces();
 
@@ -140,5 +144,9 @@ private:
     Microsoft::WRL::ComPtr<IDxcUtils> m_dxcUtils;
     Microsoft::WRL::ComPtr<IDxcIncludeHandler> m_dxcIncludeHandler;
     Microsoft::WRL::ComPtr<IDxcCompiler3> m_dxcCompiler;
+#endif
+
+#if defined(DX_PRESENT_SEPARATOR)
+    Microsoft::WRL::ComPtr<struct IDXGISwapChain1> m_dummySwapChain;
 #endif
 };

--- a/DxDispatch/src/dxdispatch/Executor.cpp
+++ b/DxDispatch/src/dxdispatch/Executor.cpp
@@ -324,6 +324,13 @@ void Executor::operator()(const Model::DispatchCommand& command)
                 // Not particularly precise (may be off by some milliseconds). Consider using OS APIs in the future.
                 std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<size_t>(timeToSleep)));
             }
+
+#if defined(DX_PRESENT_SEPARATOR)
+            if (m_commandLineArgs.GetPresentSeparator())
+            {
+                m_device->DummyPreset();
+            }
+#endif
         }
     }
     catch (const std::exception& e)

--- a/NOTICE
+++ b/NOTICE
@@ -1646,3 +1646,27 @@ the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <http://www.gnu.org/philosophy/why-not-lgpl.html>.
 ---------------------------------------------------------
+
+NvVlad/DirectML:DXDISPATCH_PRESENT_SEPARATOR - MIT
+
+MIT License
+
+Copyright © 2024 NVIDIA Corporation.  All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE


### PR DESCRIPTION
Optional argument "--present_separator" which injects a present between each inference iteration. This is helpful for external tools which require a notion of frames to digest the captured data.

The functionality is only compiled into the binary if DX_PRESENT_SEPARATOR is defined.