### PR TITLE
Support constant data nodes in DirectMLX

### DIFF
--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -1095,6 +1095,9 @@ namespace dml
     }
     
 #if DML_TARGET_VERSION >= 0x6200
+    // Creates a constant node in the graph that directly consumes memory accessible to the CPU.
+    // The graph node is a weak reference to the memory, so the backing memory must remain valid
+    // until the DMLX graph is compiled.
     inline Expression ConstantData(Graph& graph, Span<const Byte> data, TensorDesc desc)
     {
         detail::GraphBuilder* builder = graph.Impl();

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -4366,7 +4366,7 @@ namespace dml
                     {
                         // Operator nodes and constant nodes are merged into a single node array
                         // with all operator nodes appearing before all constant nodes. The node index 
-                        // of the constant node withing DML_GRAPH_DESC is the number of operator nodes plus 
+                        // of the constant node within DML_GRAPH_DESC is the number of operator nodes plus 
                         // the constant index.
                         DML_INTERMEDIATE_GRAPH_EDGE_DESC intermediateEdge = {};
                         intermediateEdge.FromNodeIndex = static_cast<uint32_t>(m_operatorNodes.size()) + inputNode.index;

--- a/Libraries/DirectMLX.h
+++ b/Libraries/DirectMLX.h
@@ -4432,6 +4432,9 @@ namespace dml
 
             // Sanity
             assert(desc.operatorNodes.size() == m_operatorNodes.size());
+#if DML_TARGET_VERSION >= 0x6200
+            assert(desc.constantNodes.size() == m_constantNodes.size());
+#endif // DML_TARGET_VERSION >= 0x6200
             assert(desc.outputEdges.size() == desc.outputCount);
             assert(desc.outputCount == outputs.size());
 

--- a/Samples/HelloDirectML/main.cpp
+++ b/Samples/HelloDirectML/main.cpp
@@ -205,7 +205,7 @@ int main()
     dml::Expression input = dml::InputTensor(graph, 0, desc);
 
 #if MULTIPLY_WITH_SCALAR_CONSTANT
-    // The memory referenced by any constant nodes (e.g., data vector) needs to be kept alive until the graph is compiled.
+    // The memory referenced by any constant nodes (e.g, "scalar" below) needs to be kept alive until the graph is compiled.
     float scalar = 3.4f;
     auto constValue = dml::ConstantData(graph, 
         dml::Span<const dml::Byte>(reinterpret_cast<const dml::Byte*>(&scalar), sizeof(scalar)),

--- a/Samples/HelloDirectML/main.cpp
+++ b/Samples/HelloDirectML/main.cpp
@@ -207,10 +207,10 @@ int main()
 #if MULTIPLY_WITH_SCALAR_CONSTANT
     // The memory referenced by any constant nodes (e.g, "scalar" below) needs to be kept alive until the graph is compiled.
     float scalar = 3.4f;
-    auto constValue = dml::ConstantData(graph, 
+    auto constValue = dml::ConstantData(
+        graph, 
         dml::Span<const dml::Byte>(reinterpret_cast<const dml::Byte*>(&scalar), sizeof(scalar)),
-        dml::TensorDesc{ DML_TENSOR_DATA_TYPE_FLOAT32, {1} }
-    );
+        dml::TensorDesc{ DML_TENSOR_DATA_TYPE_FLOAT32, {1} });
 
     // Creates the DirectMLX Graph then takes the compiled operator(s) and attaches it to the relative COM Interface.
     dml::Expression output = dml::Identity(input) * dml::Reinterpret(constValue, dimensions, dml::TensorStrides{ 0,0,0,0 });

--- a/Samples/HelloDirectML/main.cpp
+++ b/Samples/HelloDirectML/main.cpp
@@ -5,6 +5,10 @@
 
 #pragma warning(disable : 4238) // References to temporary classes are okay because they are only used as function parameters.
 
+// Enable this to show element-wise identity multiplied by a scalar placed in a constant node.
+// This only applies to the DirectMLX API that builds a graph.
+#define MULTIPLY_WITH_SCALAR_CONSTANT 0
+
 using Microsoft::WRL::ComPtr;
 
 void InitializeDirect3D12(
@@ -200,8 +204,20 @@ int main()
     dml::TensorDesc desc = { DML_TENSOR_DATA_TYPE_FLOAT32, dimensions};
     dml::Expression input = dml::InputTensor(graph, 0, desc);
 
+#if MULTIPLY_WITH_SCALAR_CONSTANT
+    // The memory referenced by any constant nodes (e.g., data vector) needs to be kept alive until the graph is compiled.
+    std::vector<float> data = { 3.4f };
+    auto constValue = dml::ConstantData(graph, 
+        dml::Span<const dml::Byte>(reinterpret_cast<const dml::Byte*>(data.data()), data.size() * sizeof(data[0])),
+        dml::TensorDesc{ DML_TENSOR_DATA_TYPE_FLOAT32, {1} }
+    );
+
+    // Creates the DirectMLX Graph then takes the compiled operator(s) and attaches it to the relative COM Interface.
+    dml::Expression output = dml::Identity(input) * dml::Reinterpret(constValue, dimensions, dml::TensorStrides{ 0,0,0,0 });
+#else
     // Creates the DirectMLX Graph then takes the compiled operator(s) and attaches it to the relative COM Interface.
     dml::Expression output = dml::Identity(input);
+#endif
 
     DML_EXECUTION_FLAGS executionFlags = DML_EXECUTION_FLAG_ALLOW_HALF_PRECISION_COMPUTATION;
     dmlCompiledOperator.Attach(graph.Compile(executionFlags, { output }).Detach());
@@ -292,7 +308,7 @@ int main()
         THROW_IF_FAILED(d3D12Device->CreateCommittedResource(
             &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
             D3D12_HEAP_FLAG_NONE,
-            &CD3DX12_RESOURCE_DESC::Buffer(persistentResourceSize),
+            &CD3DX12_RESOURCE_DESC::Buffer(persistentResourceSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS),
             D3D12_RESOURCE_STATE_COMMON,
             nullptr,
             IID_GRAPHICS_PPV_ARGS(persistentBuffer.GetAddressOf())));

--- a/Samples/HelloDirectML/main.cpp
+++ b/Samples/HelloDirectML/main.cpp
@@ -206,9 +206,9 @@ int main()
 
 #if MULTIPLY_WITH_SCALAR_CONSTANT
     // The memory referenced by any constant nodes (e.g., data vector) needs to be kept alive until the graph is compiled.
-    std::vector<float> data = { 3.4f };
+    float scalar = 3.4f;
     auto constValue = dml::ConstantData(graph, 
-        dml::Span<const dml::Byte>(reinterpret_cast<const dml::Byte*>(data.data()), data.size() * sizeof(data[0])),
+        dml::Span<const dml::Byte>(reinterpret_cast<const dml::Byte*>(&scalar), sizeof(scalar)),
         dml::TensorDesc{ DML_TENSOR_DATA_TYPE_FLOAT32, {1} }
     );
 


### PR DESCRIPTION
DML feature level 6.2 supports a new node type, DML_GRAPH_NODE_TYPE_CONSTANT, which allows applications to supply constant data through a void* instead of a graph input (D3D resource). Unlike D3D resources, constant data is available during graph compilation.

This change extends the DirectMLX.h helper to support constant nodes. For efficiency, DMLX does not make a copy of the application's data; the application needs to keep the backing memory alive until graph compilation completes.