### PR TITLE
Use custom heaps by default for cache-coherent UMA devices

### DIFF
--- a/DxDispatch/CMakeLists.txt
+++ b/DxDispatch/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
-project(dxdispatch VERSION 0.17.1 LANGUAGES CXX)
+project(dxdispatch VERSION 0.17.2 LANGUAGES CXX)
 
 # ==============================================================================
 # External Libraries/Helpers

--- a/DxDispatch/src/dxdispatch/Adapter.cpp
+++ b/DxDispatch/src/dxdispatch/Adapter.cpp
@@ -68,6 +68,7 @@ std::string Adapter::GetDetailedDescription() const
         FormatBytes(m_dedicatedSystemMemory),
         FormatBytes(m_sharedSystemMemory),
         m_isSupported_D3D12_GRAPHICS,
+        m_isSupported_CORE_COMPUTE,
         m_isSupported_GENERIC_ML
         );
 }

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -122,6 +122,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
             cxxopts::value<std::string>()
         )
         (
+            "disable_custom_heaps", 
+            "Always use default heaps for resources",
+            cxxopts::value<bool>()
+        )
+        (
             "clear_shader_caches", 
             "Clears D3D shader caches before running commands", 
             cxxopts::value<bool>()
@@ -320,6 +325,11 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
     if (result.count("show_dependencies"))
     {
         m_showDependencies = result["show_dependencies"].as<bool>();
+    }
+
+    if (result.count("disable_custom_heaps"))
+    {
+        m_preferCustomHeaps = !result["disable_custom_heaps"].as<bool>();
     }
 
     if (result.count("clear_shader_caches"))

--- a/DxDispatch/src/dxdispatch/CommandLineArgs.h
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.h
@@ -28,6 +28,7 @@ public:
     bool EnableDred() const { return m_enableDred; }
     bool DisableBackgroundProcessing() const { return m_disableBackgroundProcessing; }
     bool SetStablePowerState() const { return m_setStablePowerState; }
+    bool PreferCustomHeaps() const { return m_preferCustomHeaps; }
     bool DisableAgilitySDK() const { return m_disableAgilitySDK; }
     const std::string& AdapterSubstring() const { return m_adapterSubstring; }
 
@@ -83,6 +84,7 @@ private:
     bool m_enableDred = false;
     bool m_disableBackgroundProcessing = false;
     bool m_setStablePowerState = false;
+    bool m_preferCustomHeaps = true;
     bool m_disableAgilitySDK = false;
     bool m_uavBarrierAfterDispatch = true;
     bool m_aliasingBarrierAfterDispatch = false;

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -188,7 +188,7 @@ Device::Device(
     };
 
     D3D12_FEATURE_DATA_FEATURE_LEVELS featureLevels = {};
-    featureLevels.NumFeatureLevels = ARRAYSIZE(featureLevelsList);
+    featureLevels.NumFeatureLevels = _countof(featureLevelsList);
     featureLevels.pFeatureLevelsRequested = featureLevelsList;
     THROW_IF_FAILED(m_d3d->CheckFeatureSupport(
         D3D12_FEATURE_FEATURE_LEVELS,

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -475,7 +475,12 @@ std::vector<std::byte> Device::Download(Microsoft::WRL::ComPtr<ID3D12Resource> b
 
     ComPtr<ID3D12Resource> resourceToMap;
 
-    if (m_architectureSupport && m_architectureSupport->CacheCoherentUMA)
+    // Can't assume the input buffer was created as a custom heap (e.g., ONNX dispatchable with a deferred
+    // resource allocated by the DML EP), so check the heap properties.
+    D3D12_HEAP_PROPERTIES heapProps = {};
+    D3D12_HEAP_FLAGS heapFlags = {};
+
+    if (SUCCEEDED(buffer->GetHeapProperties(&heapProps, &heapFlags)) && heapProps.MemoryPoolPreference == D3D12_MEMORY_POOL_L0)
     {
         resourceToMap = buffer;
     }

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -104,10 +104,10 @@ Device::Device(
     {
         // Attempt to create a D3D_FEATURE_LEVEL_1_0_CORE device first, in case the device supports this
         // feature level and the D3D runtime does not support D3D_FEATURE_LEVEL_1_0_GENERIC
-        // HRESULT hrUnused = m_d3dModule->CreateDevice(
-        //     adapter,
-        //     D3D_FEATURE_LEVEL_1_0_CORE,
-        //     IID_PPV_ARGS(&m_d3d));
+        HRESULT hrUnused = m_d3dModule->CreateDevice(
+            adapter,
+            D3D_FEATURE_LEVEL_1_0_CORE,
+            IID_PPV_ARGS(&m_d3d));
     }
 
     if (!m_d3d)

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -304,6 +304,16 @@ Device::~Device()
     }
 }
 
+Microsoft::WRL::ComPtr<ID3D12Resource> Device::CreatePreferredDeviceMemoryBuffer(
+    uint64_t sizeInBytes, 
+    D3D12_RESOURCE_FLAGS resourceFlags,
+    uint64_t alignment,
+    D3D12_HEAP_FLAGS heapFlags)
+{
+    return m_useCustomHeaps ? CreateCustomBuffer(sizeInBytes, resourceFlags, alignment, heapFlags) :
+                              CreateDefaultBuffer(sizeInBytes, resourceFlags, alignment, heapFlags);
+}
+
 Microsoft::WRL::ComPtr<ID3D12Resource> Device::CreateCustomBuffer(
     uint64_t sizeInBytes, 
     D3D12_RESOURCE_FLAGS resourceFlags,

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -104,10 +104,10 @@ Device::Device(
     {
         // Attempt to create a D3D_FEATURE_LEVEL_1_0_CORE device first, in case the device supports this
         // feature level and the D3D runtime does not support D3D_FEATURE_LEVEL_1_0_GENERIC
-        HRESULT hrUnused = m_d3dModule->CreateDevice(
-            adapter,
-            D3D_FEATURE_LEVEL_1_0_CORE,
-            IID_PPV_ARGS(&m_d3d));
+        // HRESULT hrUnused = m_d3dModule->CreateDevice(
+        //     adapter,
+        //     D3D_FEATURE_LEVEL_1_0_CORE,
+        //     IID_PPV_ARGS(&m_d3d));
     }
 
     if (!m_d3d)
@@ -398,6 +398,17 @@ Microsoft::WRL::ComPtr<ID3D12Resource> Device::Upload(uint64_t totalSize, gsl::s
     {
         // No need to create an upload resource if the source data is empty.
         return defaultBuffer;
+    }
+
+    D3D12_HEAP_PROPERTIES heapProperties = {};
+    D3D12_HEAP_FLAGS heapFlags = D3D12_HEAP_FLAG_NONE;
+    if (SUCCEEDED(defaultBuffer->GetHeapProperties(&heapProperties, &heapFlags)))
+    {
+        if (heapProperties.MemoryPoolPreference == D3D12_MEMORY_POOL_L0)
+        {
+            // L0 resources are not backed by memory, so we can't map them.
+            return defaultBuffer;
+        }
     }
 
     auto uploadBuffer = CreateUploadBuffer(totalSize);

--- a/DxDispatch/src/dxdispatch/Device.h
+++ b/DxDispatch/src/dxdispatch/Device.h
@@ -22,6 +22,7 @@ public:
         bool enableDred,
         bool disableBackgroundProcessing,
         bool setStablePowerState,
+        bool preferCustomHeaps,
         uint32_t maxGpuTimeMeasurements,
         std::shared_ptr<PixCaptureHelper> pixCaptureHelper,
         std::shared_ptr<D3d12Module> d3dModule,
@@ -142,6 +143,7 @@ private:
     bool m_restoreBackgroundProcessing = false;
     bool m_restoreStablePowerState = false;
     std::optional<D3D12_FEATURE_DATA_ARCHITECTURE1> m_architectureSupport;
+    bool m_useCustomHeaps = false;
 
 #ifndef DXCOMPILER_NONE
     Microsoft::WRL::ComPtr<IDxcUtils> m_dxcUtils;

--- a/DxDispatch/src/dxdispatch/Device.h
+++ b/DxDispatch/src/dxdispatch/Device.h
@@ -137,6 +137,7 @@ private:
     Microsoft::WRL::ComPtr<IDxDispatchLogger> m_logger;
     bool m_restoreBackgroundProcessing = false;
     bool m_restoreStablePowerState = false;
+    std::optional<D3D12_FEATURE_DATA_ARCHITECTURE1> m_architectureSupport;
 
 #ifndef DXCOMPILER_NONE
     Microsoft::WRL::ComPtr<IDxcUtils> m_dxcUtils;

--- a/DxDispatch/src/dxdispatch/Device.h
+++ b/DxDispatch/src/dxdispatch/Device.h
@@ -46,6 +46,14 @@ public:
     IDxcCompiler3* GetDxcCompiler();
 #endif
 
+    // Creates either a default buffer or custom buffer based on support for custom heaps
+    // and whether or not they are allowed.
+    Microsoft::WRL::ComPtr<ID3D12Resource> CreatePreferredDeviceMemoryBuffer(
+        uint64_t sizeInBytes, 
+        D3D12_RESOURCE_FLAGS resourceFlags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        uint64_t alignment = 0,
+        D3D12_HEAP_FLAGS heapFlags = D3D12_HEAP_FLAG_NONE);
+
     Microsoft::WRL::ComPtr<ID3D12Resource> CreateCustomBuffer(
         uint64_t sizeInBytes, 
         D3D12_RESOURCE_FLAGS resourceFlags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,

--- a/DxDispatch/src/dxdispatch/Device.h
+++ b/DxDispatch/src/dxdispatch/Device.h
@@ -45,7 +45,11 @@ public:
     IDxcCompiler3* GetDxcCompiler();
 #endif
 
-    // TODO: test custom heap buffer with write combine for igpu?
+    Microsoft::WRL::ComPtr<ID3D12Resource> CreateCustomBuffer(
+        uint64_t sizeInBytes, 
+        D3D12_RESOURCE_FLAGS resourceFlags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,
+        uint64_t alignment = 0,
+        D3D12_HEAP_FLAGS heapFlags = D3D12_HEAP_FLAG_NONE);
 
     Microsoft::WRL::ComPtr<ID3D12Resource> CreateDefaultBuffer(
         uint64_t sizeInBytes, 

--- a/DxDispatch/src/dxdispatch/DmlDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/DmlDispatchable.cpp
@@ -166,7 +166,7 @@ void DmlDispatchable::Initialize()
     auto tempBufferSize = initializer->GetBindingProperties().TemporaryResourceSize;
     if (tempBufferSize > 0)
     {
-        ComPtr<ID3D12Resource> tempBuffer = m_device->CreateDefaultBuffer(tempBufferSize);
+        ComPtr<ID3D12Resource> tempBuffer = m_device->CreatePreferredDeviceMemoryBuffer(tempBufferSize);
         DML_BUFFER_BINDING bufferBinding = { tempBuffer.Get(), 0, tempBufferSize };
         DML_BINDING_DESC bindingDesc = { DML_BINDING_TYPE_BUFFER, &bufferBinding };
         bindingTable->BindTemporaryResource(&bindingDesc);
@@ -177,7 +177,7 @@ void DmlDispatchable::Initialize()
     auto persistentBufferSize = m_operatorCompiled->GetBindingProperties().PersistentResourceSize;
     if (persistentBufferSize > 0)
     {
-        m_persistentBuffer = m_device->CreateDefaultBuffer(persistentBufferSize);
+        m_persistentBuffer = m_device->CreatePreferredDeviceMemoryBuffer(persistentBufferSize);
         DML_BUFFER_BINDING bufferBinding = { m_persistentBuffer.Get(), 0, persistentBufferSize };
         DML_BINDING_DESC bindingDesc = { DML_BINDING_TYPE_BUFFER, &bufferBinding };
         bindingTable->BindOutputs(1, &bindingDesc);
@@ -227,7 +227,7 @@ void DmlDispatchable::Bind(const Bindings& bindings, uint32_t iteration)
     auto tempBufferSize = bindingProps.TemporaryResourceSize;
     if (tempBufferSize > 0)
     {
-        tempBuffer = m_device->CreateDefaultBuffer(tempBufferSize);
+        tempBuffer = m_device->CreatePreferredDeviceMemoryBuffer(tempBufferSize);
 
         DML_BUFFER_BINDING bufferBinding = { tempBuffer.Get(), 0, tempBufferSize };
         DML_BINDING_DESC bindingDesc = { DML_BINDING_TYPE_BUFFER, &bufferBinding };

--- a/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
+++ b/DxDispatch/src/dxdispatch/OnnxDispatchable.cpp
@@ -419,7 +419,7 @@ void OnnxDispatchable::Bind(const Bindings& jsonBindings, uint32_t iteration)
                             {
                                 throw std::invalid_argument(fmt::format("TensorShapeUint32 '{}' is too large.", tensorShapeUint32.size()));
                             }
-                            binding.resource = m_device->CreateDefaultBuffer(DMLCalcBufferTensorSize(
+                            binding.resource = m_device->CreatePreferredDeviceMemoryBuffer(DMLCalcBufferTensorSize(
                                 dataTypeInfo.dmlDataType,
                                 static_cast<uint32_t>(tensorShapeUint32.size()),
                                 tensorShapeUint32.data(),

--- a/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
+++ b/DxDispatch/src/dxdispatch/dxDispatchWrapper.cpp
@@ -172,6 +172,7 @@ HRESULT DxDispatch::RuntimeClassInitialize(
                 m_options->EnableDred(),
                 m_options->DisableBackgroundProcessing(),
                 m_options->SetStablePowerState(),
+                m_options->PreferCustomHeaps(),
                 m_options->MaxGpuTimeMeasurements(),
                 m_pixCaptureHelper,
                 m_d3dModule,


### PR DESCRIPTION
This change avoids extra copies (uploadHeap->defaultHeap, defaultHeap->readbackHeap) by using custom heaps for adapters with cache-coherent UMA.