### PR TITLE
Fix debug callback not showing output

### DIFF
--- a/DxDispatch/CMakeLists.txt
+++ b/DxDispatch/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
-project(dxdispatch VERSION 0.17.2 LANGUAGES CXX)
+project(dxdispatch VERSION 0.17.3 LANGUAGES CXX)
 
 # ==============================================================================
 # External Libraries/Helpers

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -91,7 +91,7 @@ Device::Device(
 
     if (debugLayersEnabled)
     {
-        m_d3d->SetDebugCallbackX(DebugMessageCallback, /*context*/nullptr);
+        m_d3d->SetDebugCallbackX(DebugMessageCallback, /*context*/logger);
     }
 #else // !_GAMING_XBOX
     if (debugLayersEnabled)
@@ -139,7 +139,7 @@ Device::Device(
         m_infoQueue->RegisterMessageCallback(
             DebugMessageCallback, 
             D3D12_MESSAGE_CALLBACK_FLAG_NONE, 
-            nullptr, 
+            logger, 
             &m_callbackCookie);
     }
 

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -20,7 +20,7 @@ static void __stdcall DebugMessageCallback(D3D12_MESSAGE_CATEGORY cat, D3D12_MES
     if (context)
     {
         auto logger = (IDxDispatchLogger*)context;
-        auto fmtMessage = fmt::format("{} {} {} {}", int(cat), int(id), context, message);
+        auto fmtMessage = fmt::format("{} {} {}", int(cat), int(id), message);
         if ((D3D12_MESSAGE_SEVERITY_INFO == sev) ||
             (D3D12_MESSAGE_SEVERITY_MESSAGE == sev))
         {

--- a/DxDispatch/src/dxdispatch/Device.cpp
+++ b/DxDispatch/src/dxdispatch/Device.cpp
@@ -19,6 +19,12 @@ static void __stdcall DebugMessageCallback(D3D12_MESSAGE_CATEGORY cat, D3D12_MES
 {
     if (context)
     {
+        if (id == D3D12_MESSAGE_ID_META_COMMAND_UNSUPPORTED_PARAMS)
+        {
+            // Ignore this message, since DML internally may try to create metacommands that are not supported.
+            return;
+        }
+
         auto logger = (IDxDispatchLogger*)context;
         auto fmtMessage = fmt::format("{} {} {}", int(cat), int(id), message);
         if ((D3D12_MESSAGE_SEVERITY_INFO == sev) ||


### PR DESCRIPTION
The debug is supposed to be log info/warning/error messages, but it's been a no-op since refactoring to use a logger. Presumably the context* was supposed to be the logger instance, but this was never passed in.