### PR TITLE
Add DxDispatch PIX timing capture command line support on windows

### DIFF
--- a/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
+++ b/DxDispatch/src/dxdispatch/CommandLineArgs.cpp
@@ -437,9 +437,6 @@ CommandLineArgs::CommandLineArgs(int argc, char** argv)
         else if (pixCaptureTypeStr == "timing")
         {
             m_pixCaptureType = PixCaptureType::ProgrammaticTiming;
-#ifndef _GAMING_XBOX
-            throw std::invalid_argument("Programmatic timing captures are not supported");
-#endif
         }
         else if (pixCaptureTypeStr == "manual")
         {

--- a/DxDispatch/src/dxdispatch/PixCaptureHelper.cpp
+++ b/DxDispatch/src/dxdispatch/PixCaptureHelper.cpp
@@ -92,7 +92,6 @@ HRESULT PixCaptureHelper::BeginCapturableWork()
             captureParams.TimingCaptureParameters.CaptureCpuSamples = TRUE;
             captureParams.TimingCaptureParameters.CpuSamplesPerSecond = 4000;
             captureParams.TimingCaptureParameters.CaptureStorage = PIXCaptureParameters::Memory;
-            captureParams.TimingCaptureParameters.FileName = captureName.data();
             captureParams.TimingCaptureParameters.MaximumToolingMemorySizeMb = 4096;
             return PIXBeginCapture(PIX_CAPTURE_TIMING, &captureParams);
 #endif

--- a/DxDispatch/src/dxdispatch/PixCaptureHelper.cpp
+++ b/DxDispatch/src/dxdispatch/PixCaptureHelper.cpp
@@ -81,7 +81,7 @@ HRESULT PixCaptureHelper::BeginCapturableWork()
 #else
             if (!m_timingCaptureLibrary)
             {
-                throw std::runtime_error("The WinPix Timing capturer library was not found. Ensure PIX is installed.");
+                throw std::runtime_error("The WinPix Timing capturer library was not found. Ensure that PIX version 2303.02 or later is installed.");
             }
             auto captureName = m_captureName + L".wpix";
 
@@ -93,7 +93,12 @@ HRESULT PixCaptureHelper::BeginCapturableWork()
             captureParams.TimingCaptureParameters.CpuSamplesPerSecond = 4000;
             captureParams.TimingCaptureParameters.CaptureStorage = PIXCaptureParameters::Memory;
             captureParams.TimingCaptureParameters.MaximumToolingMemorySizeMb = 4096;
-            return PIXBeginCapture(PIX_CAPTURE_TIMING, &captureParams);
+            HRESULT hr = PIXBeginCapture(PIX_CAPTURE_TIMING, &captureParams);
+            if (hr == E_ACCESSDENIED)
+            {
+                throw std::runtime_error("E_ACCESSDENIED while attempting to begin PIX timing capture.  Timing capture requires elevated privileges.");
+            }
+            return hr;
 #endif
         }
 
@@ -158,7 +163,8 @@ HRESULT PixCaptureHelper::EndCapturableWork()
 
             return hr;
 #else
-            // PIX on Windows ignores the discard parameter.
+            // PIX on Windows ignores the discard parameter, and will flush internally,
+            // no need for the loop xbox needs above.
             return PIXEndCapture(/*discard*/FALSE);
 #endif
         }

--- a/DxDispatch/src/dxdispatch/PixCaptureHelper.h
+++ b/DxDispatch/src/dxdispatch/PixCaptureHelper.h
@@ -35,6 +35,7 @@ private:
     Microsoft::WRL::ComPtr<ID3D12CommandQueue> m_commandQueue;
 #if !defined(_GAMING_XBOX) && !defined(PIX_NONE)
     wil::unique_hmodule m_gpuCaptureLibrary;
+    wil::unique_hmodule m_timingCaptureLibrary;
     Microsoft::WRL::ComPtr<ID3D12SharingContract> m_sharingContract;
 #endif
 };


### PR DESCRIPTION
Recent WinPix releases have added support for programmatic timing captures.  This change enables that functionality via the "-c timing" argument to DxDispatch.