### PR TITLE
Use ORT 1.18 for ESRGAN sample

### DIFF
--- a/Samples/DirectML_ESRGAN/CMakeLists.txt
+++ b/Samples/DirectML_ESRGAN/CMakeLists.txt
@@ -37,8 +37,8 @@ target_include_directories(wil INTERFACE "${wil_SOURCE_DIR}/include")
 # -----------------------------------------------------------------------------
 FetchContent_Declare(
     ort
-    URL https://www.nuget.org/api/v2/package/Microsoft.ML.OnnxRuntime.DirectML/1.19.0
-    URL_HASH SHA256=FD4E65EBD23385FD8ED792F0C859D2AA255DC1761D0E5761087568FF255187AC
+    URL https://www.nuget.org/api/v2/package/Microsoft.ML.OnnxRuntime.DirectML/1.18.0
+    URL_HASH SHA256=16D73AF3FC1EDD8392E8B6843FDEA281E89EE68A0C78DDE6325C30D20080EEE5
 )
 
 FetchContent_MakeAvailable(ort)


### PR DESCRIPTION
Update ORT to 1.18 for ESRGAN sample because it will be used as an example for Qualcomm NPU launch and for ORT native path 1.18 is more compatible as compared to 1.19. It is so because the extra ORT optimization payload present in ORT1.19 will change the DML graph hash present in DML1.15.2.