### PR TITLE
Samples/DirectMLNpuInference/main: switch from void main to int main

### DIFF
--- a/Samples/DirectMLNpuInference/main.cpp
+++ b/Samples/DirectMLNpuInference/main.cpp
@@ -104,7 +104,7 @@ void InitializeDirectML(ID3D12Device1** d3dDeviceOut, ID3D12CommandQueue** comma
     dmlDevice.CopyTo(dmlDeviceOut);
 }
 
-void main()
+int main()
 {
     ComPtr<ID3D12Device1> d3dDevice;
     ComPtr<IDMLDevice> dmlDevice;
@@ -194,4 +194,5 @@ void main()
     // Read results
     ComPtr<ID3D12Resource> outputResource;
     Ort::ThrowOnError(ortDmlApi->GetD3D12ResourceFromAllocation(allocator, outputTensor.GetTensorMutableData<void*>(), &outputResource));
+    return 0;
 }


### PR DESCRIPTION
void main is a non-standard C++ extension. 

From https://learn.microsoft.com/en-us/cpp/cpp/main-function-command-line-args?view=msvc-170 

> As a Microsoft extension, the main and wmain functions can be declared as returning void (no return value). This extension is also available in some other compilers, but its use isn't recommended. It's available for symmetry when main doesn't return a value.