### PR TITLE
DxDispatch add print verbose option including exact bit patterns via hex

### DIFF
--- a/DxDispatch/doc/Guide.md
+++ b/DxDispatch/doc/Guide.md
@@ -810,12 +810,13 @@ cbuffer constants { uint elementCount; };
 
 ### Print
 
-This command is used to print the contents of a resource to stdout. If the resource lives in a GPU-visible-only heap then it will first be downloaded into a CPU-visible readback heap. Buffers are always printed as a flat 1D view of elements: the data type and number of elements display will be derived using the resource's initializer. More control over printing may be added in the future.
+This command is used to print the contents of a resource to stdout. If the resource lives in a GPU-visible-only heap then it will first be downloaded into a CPU-visible readback heap. Buffers are always printed as a flat 1D view of elements: the data type and number of elements display will be derived using the resource's initializer. The optional `verbose` option prints the raw value's data as hexadecimal. More control over printing may be added in the future.
 
 ```json
 { 
-    "type": "print", 
-    "resource": "Out" 
+    "type": "print",
+    "resource": "Out",
+    "verbose": false
 }
 ```
 

--- a/DxDispatch/models/_schema.json
+++ b/DxDispatch/models/_schema.json
@@ -402,6 +402,11 @@
                 {
                     "type": "string",
                     "description": "Name of the resource to display"
+                },
+                "verbose":
+                {
+                    "type": "boolean",
+                    "description": "Whether to print raw data values too"
                 }
             },
             "required": ["resource"]

--- a/DxDispatch/src/model/JsonParsers.cpp
+++ b/DxDispatch/src/model/JsonParsers.cpp
@@ -1627,6 +1627,7 @@ Model::PrintCommand ParsePrintCommand(const rapidjson::Value& object)
 {
     Model::PrintCommand command = {};
     command.resourceName = ParseStringField(object, "resource");
+    command.verbose = ParseBoolField(object, "verbose", false, false);
     return command;
 }
 

--- a/DxDispatch/src/model/Model.h
+++ b/DxDispatch/src/model/Model.h
@@ -138,6 +138,7 @@ public:
     struct PrintCommand
     {
         std::string resourceName;
+        bool verbose;
     };
 
     struct WriteFileCommand


### PR DESCRIPTION
To verify some small differences between GPU's (for WebNN failure diagnostic):

```json
    "commands": 
    [
        {
            "type": "dispatch",
            "dispatchable": "batchNormalization",
            "bindings": 
            {
                "InputTensor": "input",
                "MeanTensor": "mean",
                "VarianceTensor": "variance",
                "ScaleTensor": "scale",
                "BiasTensor": "bias",
                "OutputTensor": "output"
            }
        },
        { "type": "print", "resource": "output"},
        { "type": "print", "resource": "output", "verbose": false},
        { "type": "print", "resource": "output", "verbose": true} // <-----
    ]
```
![image](https://github.com/user-attachments/assets/0a01eb42-c104-411c-82ce-0ca76e061704)
