### PR TITLE
DxDispatch print verbose hex as hex

### DIFF
--- a/DxDispatch/src/dxdispatch/Executor.cpp
+++ b/DxDispatch/src/dxdispatch/Executor.cpp
@@ -479,7 +479,7 @@ std::ostream& operator<<(std::ostream& os, const BufferDataView<T>& view)
 
             os << fmt::format("[{:{}}] ", elementIndex, elementIndexWidth);
             os << value;
-            os << fmt::format(" (0x{:{}})\n", scalarUnion.UInt64, hexDigitWidth);
+            os << fmt::format(" (0x{:{}X})\n", scalarUnion.UInt64, hexDigitWidth);
         }
         else
         {


### PR DESCRIPTION
Sigh, third time is a charm 🤦‍♂️😔.
- Print hex as hex, addressing @BruceDai's comment: https://github.com/microsoft/DirectML/pull/706#pullrequestreview-2937898952

![image](https://github.com/user-attachments/assets/361a5dc5-f62a-473e-b902-5cfed10b2e74)