### PR TITLE
Fix Python build for activation_soft_max function

### DIFF
--- a/Python/src/module.cpp
+++ b/Python/src/module.cpp
@@ -554,7 +554,9 @@ PYBIND11_MODULE(pydirectml, module)
         py::arg("new_size"),
         py::arg("new_strides"));
 
-    module.def("activation_soft_max", &dml::ActivationSoftmax, "Raise all elements to e, and divide all the elements in each batch by that batch's sum.",
+    module.def("activation_soft_max", [](dml::Expression input) {
+        return dml::ActivationSoftmax(input);
+    }, "Raise all elements to e, and divide all the elements in each batch by that batch's sum.",
         py::arg("input"));
 
     module.def("join", [](


### PR DESCRIPTION
There is a function overload for `ActivationSoftmax`, so the Python build will encounter this error:

```
    C:\Users\xxxxx\Source\DirectML\Python\src\module.cpp(557,12): error C2672: 'pybind11::module_::def': no matching overloaded function found [C:\Users\xxxxx\Source\DirectML\Python\build\temp.win-amd64-cpython-310\Release\pydirectml.vcxproj]
          C:\Users\xxxxx\Source\DirectML\Python\pybind11\include\pybind11\pybind11.h(1162,14):
          could be 'pybind11::module_ &pybind11::module_::def(const char *,Func &&,const Extra ...)'
              C:\Users\xxxxx\Source\DirectML\Python\src\module.cpp(557,12):
              'pybind11::module_ &pybind11::module_::def(const char *,Func &&,const Extra ...)': could not deduce template argument for 'Func'
```